### PR TITLE
Feature: Add dialog component.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -847,6 +847,41 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "license": "MIT",
@@ -8222,6 +8257,7 @@
         "@floating-ui/react": "^0.27.13",
         "@headlessui/react": "^2.2.6",
         "@popperjs/core": "^2.11.8",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tailwindcss/vite": "^4.1.11",

--- a/packages/frappe-components/package.json
+++ b/packages/frappe-components/package.json
@@ -17,6 +17,7 @@
     "@floating-ui/react": "^0.27.13",
     "@headlessui/react": "^2.2.6",
     "@popperjs/core": "^2.11.8",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tailwindcss/vite": "^4.1.11",

--- a/packages/frappe-components/src/components/autoComplete/autoComplete.stories.tsx
+++ b/packages/frappe-components/src/components/autoComplete/autoComplete.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof Autocomplete> = {
   component: Autocomplete,
   tags: ["autodocs"],
   argTypes: {
-    modelValue: {
+    value: {
       control: "object",
       description: "The currently selected value(s).",
     },
@@ -82,7 +82,7 @@ const meta: Meta<typeof Autocomplete> = {
       description: "CSS classes for the popover body.",
     },
     onChange: {
-      action: "update:modelValue",
+      action: "update:value",
       description: "Event when selection changes.",
     },
   },
@@ -108,7 +108,7 @@ export const SingleOption: Story = {
       <div style={{ width: "450px" }}>
         <Autocomplete
           {...args}
-          modelValue={value}
+          value={value}
           onChange={(_value) => {
             setValue(_value as string);
           }}
@@ -129,7 +129,7 @@ export const SingleOptionWithPrefixSlots: Story = {
       <div style={{ width: "450px" }}>
         <Autocomplete
           {...args}
-          modelValue={value}
+          value={value}
           prefix={(value) =>  <img src={value?.image ?? ''} className="mr-2 h-4 w-4 rounded-full" />}
           itemPrefix={(value) =>  <img src={value?.image ?? ''} className="ml-2 h-4 w-4 rounded-full" />}
           onChange={(_value) => {
@@ -155,7 +155,7 @@ export const SingleOptionWithoutSearch: Story = {
         <Autocomplete
           {...args}
           hideSearch
-          modelValue={values}
+          value={values}
           onChange={(_value) => {
             setValues(_value as string[]);
           }}
@@ -180,7 +180,7 @@ export const MultipleOptions: Story = {
         <Autocomplete
           {...args}
           multiple
-          modelValue={value}
+          value={value}
           onChange={(_value) => {
             setValue(_value as string);
           }}
@@ -204,7 +204,7 @@ export const MultipleOptionsWithoutSearch: Story = {
           {...args}
           hideSearch
           multiple
-          modelValue={value}
+          value={value}
           onChange={(_value) => {
             setValue(_value as string);
           }}

--- a/packages/frappe-components/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-components/src/components/autoComplete/autoComplete.tsx
@@ -18,7 +18,7 @@ import FeatherIcon from "../featherIcon";
 import type { AutocompleteOption, AutocompleteOptionGroup, AutocompleteProps, Option } from "./types";
 
 const Autocomplete: React.FC<AutocompleteProps> = ({
-  modelValue,
+  value,
   options,
   multiple = false,
   label,
@@ -154,20 +154,20 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   );
 
   const selectedComboboxValue = useMemo<Option | Option[] | null>(() => {
-    if (modelValue === null || modelValue === undefined) {
+    if (value === null || value === undefined) {
       return multiple ? [] : null;
     }
 
     if (!multiple) {
       return (
-        findOption(modelValue as AutocompleteOption) ||
-        makeOption(modelValue as AutocompleteOption)
+        findOption(value as AutocompleteOption) ||
+        makeOption(value as AutocompleteOption)
       );
     }
 
-    const values = Array.isArray(modelValue) ? modelValue : [];
+    const values = Array.isArray(value) ? value : [];
     return values.map((v) => findOption(v) || makeOption(v));
-  }, [modelValue, multiple, findOption, makeOption]);
+  }, [value, multiple, findOption, makeOption]);
 
   const handleComboboxChange = useCallback(
     (val: Option | Option[] | null) => {

--- a/packages/frappe-components/src/components/autoComplete/types.ts
+++ b/packages/frappe-components/src/components/autoComplete/types.ts
@@ -22,7 +22,7 @@ export type AutocompleteOptionGroup = {
 export type AutocompleteOptions = AutocompleteOption[] | AutocompleteOptionGroup[];
 
 export interface AutocompleteProps {
-  modelValue: AutocompleteOption | AutocompleteOption[] | null | undefined;
+  value: AutocompleteOption | AutocompleteOption[] | null | undefined;
   options: AutocompleteOptions;
   multiple?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/frappe-components/src/components/button/Button.tsx
+++ b/packages/frappe-components/src/components/button/Button.tsx
@@ -19,6 +19,7 @@ const Button: React.FC<ButtonProps> = ({
   suffixIcon,
   icon,
   children,
+  extraClassName,
   ...rest
 }) => {
   const navigate = useNavigate();
@@ -82,8 +83,9 @@ const Button: React.FC<ButtonProps> = ({
       isDisabled ? disabledClass : variantClass,
       focusClasses[theme],
       sizeClass,
+      extraClassName
     ].filter(Boolean).join(' ');
-  }, [theme, variant, size, isIconButton, isDisabled]);
+  }, [theme, variant, size, isIconButton, isDisabled, extraClassName]);
 
   const buttonContent: ReactNode = useMemo(() => {
     if (loading) {
@@ -104,7 +106,6 @@ const Button: React.FC<ButtonProps> = ({
       </>
     );
   }, [loading, loadingText, isIconButton, icon, prefixIcon, children, label, suffixIcon]);
-
 
   const loadingIndicatorSizeClass = useMemo(() => {
     return {

--- a/packages/frappe-components/src/components/button/constants.ts
+++ b/packages/frappe-components/src/components/button/constants.ts
@@ -1,58 +1,58 @@
 import type { ButtonTheme, ThemeVariant } from "./types";
 
 export const solidClasses: Record<ButtonTheme, string> = {
-    gray: 'text-(--ink-white) bg-(--surface-gray-7) hover:bg-(--surface-gray-6) active:bg-(--surface-gray-5)',
-    blue: 'text-(--ink-white) bg-blue-500 hover:bg-(--surface-blue-3) active:bg-blue-700',
-    green: 'text-(--ink-white) bg-(--surface-green-3) hover:bg-green-700 active:bg-green-800',
-    red: 'text-(--ink-white) bg-(--surface-red-5) hover:bg-(--surface-red-6) active:bg-(--surface-red-7)',
+    gray: 'text-ink-white bg-surface-gray-7 hover:bg-surface-gray-6 active:bg-surface-gray-5',
+    blue: 'text-ink-white bg-blue-500 hover:bg-surface-blue-3 active:bg-blue-700',
+    green: 'text-ink-white bg-surface-green-3 hover:bg-green-700 active:bg-green-800',
+    red: 'text-ink-white bg-surface-red-5 hover:bg-surface-red-6 active:bg-surface-red-7',
 };
 
 export const subtleClasses: Record<ButtonTheme, string> = {
-    gray: 'text-(--ink-gray-8) bg-(--surface-gray-2) hover:bg-(--surface-gray-3) active:bg-(--surface-gray-4)',
-    blue: 'text-(--ink-blue-3) bg-(--surface-blue-2) hover:bg-blue-200 active:bg-blue-300',
-    green: 'text-green-800 bg-(--surface-green-2) hover:bg-green-200 active:bg-green-300',
-    red: 'text-red-700 bg-(--surface-red-2) hover:bg-(--surface-red-3) active:bg-(--surface-red-4)',
+    gray: 'text-ink-gray-8 bg-surface-gray-2 hover:bg-surface-gray-3 active:bg-surface-gray-4',
+    blue: 'text-ink-blue-3 bg-surface-blue-2 hover:bg-blue-200 active:bg-blue-300',
+    green: 'text-green-800 bg-surface-green-2 hover:bg-green-200 active:bg-green-300',
+    red: 'text-red-700 bg-surface-red-2 hover:bg-surface-red-3 active:bg-surface-red-4',
 };
 
 export const outlineClasses: Record<ButtonTheme, string> = {
-    gray: 'text-(--ink-gray-8) bg-(--surface-white) border border-(--outline-gray-2) hover:border-(--outline-gray-3) active:border-(--outline-gray-3) active:bg-(--surface-gray-4)',
-    blue: 'text-(--ink-blue-3) bg-(--surface-white) border border-(--outline-blue-1) hover:border-blue-400 active:border-blue-400 active:bg-blue-300',
-    green: 'text-green-800 bg-(--surface-white) border border-(--outline-green-2) hover:border-green-500 active:border-green-500) active:bg-green-300',
-    red: 'text-red-700 bg-(--surface-white) border border-(--outline-red-1) hover:border-(--outline-red-2) active:border-(--outline-red-2) active:bg-(--surface-red-3)',
+    gray: 'text-ink-gray-8 bg-surface-white border border-outline-gray-2 hover:border-outline-gray-3 active:border-outline-gray-3 active:bg-surface-gray-4',
+    blue: 'text-ink-blue-3 bg-surface-white border border-outline-blue-1 hover:border-blue-400 active:border-blue-400 active:bg-blue-300',
+    green: 'text-green-800 bg-surface-white border border-outline-green-2 hover:border-green-500 active:border-green-500 active:bg-green-300',
+    red: 'text-red-700 bg-surface-white border border-outline-red-1 hover:border-outline-red-2 active:border-outline-red-2 active:bg-surface-red-3',
 };
 
 export const ghostClasses: Record<ButtonTheme, string> = {
-    gray: 'text-(--ink-gray-8) bg-transparent hover:bg-(--surface-gray-3) active:bg-(--surface-gray-4)',
-    blue: 'text-(--ink-blue-3) bg-transparent hover:bg-blue-200 active:bg-blue-300',
+    gray: 'text-ink-gray-8 bg-transparent hover:bg-surface-gray-3 active:bg-surface-gray-4',
+    blue: 'text-ink-blue-3 bg-transparent hover:bg-blue-200 active:bg-blue-300',
     green: 'text-green-800 bg-transparent hover:bg-green-200 active:bg-green-300',
-    red: 'text-red-700 bg-transparent hover:bg-(--surface-red-3) active:bg-(--surface-red-4)',
+    red: 'text-red-700 bg-transparent hover:bg-surface-red-3 active:bg-surface-red-4',
 };
 
 export const focusClasses: Record<ButtonTheme, string> = {
-    gray: 'focus-visible:ring focus-visible:ring-(--outline-gray-3)',
+    gray: 'focus-visible:ring focus-visible:ring-outline-gray-3',
     blue: 'focus-visible:ring focus-visible:ring-blue-400',
-    green: 'focus-visible:ring focus-visible:ring-(--outline-green-2)',
-    red: 'focus-visible:ring focus-visible:ring-(--outline-red-2)',
+    green: 'focus-visible:ring focus-visible:ring-outline-green-2',
+    red: 'focus-visible:ring focus-visible:ring-outline-red-2',
 };
 
 export const disabledClassesMap: Record<ThemeVariant, string> = {
-    'gray-solid': 'bg-(--surface-gray-2) text-(--ink-gray-4)',
-    'gray-subtle': 'bg-(--surface-gray-2) text-(--ink-gray-4)',
-    'gray-outline': 'bg-(--surface-gray-2) text-(--ink-gray-4) border border-(--outline-gray-2)',
-    'gray-ghost': 'text-(--ink-gray-4)',
+    'gray-solid': 'bg-surface-gray-2 text-ink-gray-4',
+    'gray-subtle': 'bg-surface-gray-2 text-ink-gray-4',
+    'gray-outline': 'bg-surface-gray-2 text-ink-gray-4 border border-outline-gray-2',
+    'gray-ghost': 'text-ink-gray-4',
 
-    'blue-solid': 'bg-blue-300 text-(--ink-white)',
-    'blue-subtle': 'bg-(--surface-blue-2 text-(--ink-blue-link)',
-    'blue-outline': 'bg-(--surface-blue-2 text-(--ink-blue-link) border border-(--outline-blue-1)',
-    'blue-ghost': 'text-(--ink-blue-link)',
+    'blue-solid': 'bg-blue-300 text-ink-white',
+    'blue-subtle': 'bg-surface-blue-2 text-ink-blue-link',
+    'blue-outline': 'bg-surface-blue-2 text-ink-blue-link border border-outline-blue-1',
+    'blue-ghost': 'text-ink-blue-link',
 
-    'green-solid': 'bg-(--surface-green-2) text-(--ink-green-2)',
-    'green-subtle': 'bg-(--surface-green-2) text-(--ink-green-2)',
-    'green-outline': 'bg-(--surface-green-2) text-(--ink-green-2) border border-(--outline-green-2)',
-    'green-ghost': 'text-(--ink-green-2)',
+    'green-solid': 'bg-surface-green-2 text-ink-green-2',
+    'green-subtle': 'bg-surface-green-2 text-ink-green-2',
+    'green-outline': 'bg-surface-green-2 text-ink-green-2 border border-outline-green-2',
+    'green-ghost': 'text-ink-green-2',
 
-    'red-solid': 'bg-(--surface-red-2) text-(--ink-red-2)',
-    'red-subtle': 'bg-(--surface-red-2) text-(--ink-red-2)',
-    'red-outline': 'bg-(--(--surface-red-2) text-(--ink-red-2) border border-(--outline-red-1)',
-    'red-ghost': 'text-(--ink-red-2)',
+    'red-solid': 'bg-surface-red-2 text-ink-red-2',
+    'red-subtle': 'bg-surface-red-2 text-ink-red-2',
+    'red-outline': 'bg-surface-red-2 text-ink-red-2 border border-outline-red-1',
+    'red-ghost': 'text-ink-red-2',
   };

--- a/packages/frappe-components/src/components/button/types.ts
+++ b/packages/frappe-components/src/components/button/types.ts
@@ -25,6 +25,7 @@ export interface ButtonProps {
   suffixIcon?: ReactNode;
   icon?: ReactNode;
   children?: ReactNode;
+  extraClassName?: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/packages/frappe-components/src/components/checkbox/checkbox.tsx
+++ b/packages/frappe-components/src/components/checkbox/checkbox.tsx
@@ -5,7 +5,6 @@ import type { SizeTypes } from '../../types';
 const Checkbox: React.FC<CheckboxProps> = ({
   size = 'sm',
   label,
-  checked,
   disabled = false,
   padding = false,
   value,
@@ -50,7 +49,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
     if(padding && size === 'md'){
         paddingClasses = 'px-3 py-2'
     }
-    console.log(paddingClasses, padding, size)
+
     const interactionClasses = padding && !disabled
       ? 'focus-within:bg-surface-gray-2 focus-within:ring-2 focus-within:ring-outline-gray-3 hover:bg-surface-gray-3 active:bg-surface-gray-4'
       : '';
@@ -62,8 +61,6 @@ const Checkbox: React.FC<CheckboxProps> = ({
     onChange?.(e.target.checked);
   },[onChange]);
 
-  const valueToUse = typeof checked === 'undefined' ? value : checked;
-  console.log(checked, valueToUse, value)
   return (
     <div className={wrapperClasses}>
       <input

--- a/packages/frappe-components/src/components/dialog/dialog.css
+++ b/packages/frappe-components/src/components/dialog/dialog.css
@@ -1,0 +1,55 @@
+@keyframes dialog-overlay-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes dialog-overlay-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes dialog-content-in {
+  from {
+    opacity: 0.5;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes dialog-content-out {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+  to {
+    opacity: 0.5;
+    transform: scale(0.98);
+  }
+}
+
+.dialog-overlay[data-state='open'] {
+  animation: dialog-overlay-in 100ms ease-out;
+}
+
+.dialog-overlay[data-state='closed'] {
+  animation: dialog-overlay-out 150ms ease-in;
+}
+
+.dialog-content[data-state='open'] {
+  animation: dialog-content-in 100ms ease-out;
+}
+
+.dialog-content[data-state='closed'] {
+  animation: dialog-content-out 150ms ease-in;
+}

--- a/packages/frappe-components/src/components/dialog/dialog.stories.tsx
+++ b/packages/frappe-components/src/components/dialog/dialog.stories.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Dialog, DialogOptions } from './dialog';
+import { Button } from '../button';
+import { Dropdown } from '../dropdown';
+import { Autocomplete, AutocompleteOption } from '../autoComplete';
+import FeatherIcon from '../featherIcon';
+import { MemoryRouter } from 'react-router';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Components/Dialog',
+  component: Dialog,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+      <div style={{ display: 'grid', gap: '1rem', gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))' }}>
+        <Story />
+      </div>
+      </MemoryRouter>
+    ),
+  ],
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+const createPromise = (): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 2000);
+  });
+};
+
+export const BasicConfirmation: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const dialogOptions: DialogOptions = {
+      title: 'Confirm Action',
+      message: 'Are you sure you want to proceed with this action?',
+      size: 'lg',
+      icon: {
+        name: 'alert-triangle',
+        appearance: 'warning',
+      },
+      actions: [
+        {
+          label: 'Confirm',
+          variant: 'solid',
+          onClick: () => createPromise(),
+        },
+      ],
+    };
+
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Show Confirmation Dialog</Button>
+        <Dialog open={isOpen} onOpenChange={setIsOpen} options={dialogOptions} />
+      </div>
+    );
+  },
+};
+
+export const CustomContent: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Show Custom Dialog</Button>
+        <Dialog
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          options={{
+            title: () => <h3 className="text-2xl font-semibold text-blue-600">Custom Title with Styling</h3>
+          }}
+          actions={
+            <div className="flex justify-start flex-row-reverse gap-2">
+              <Button variant="solid" style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)}>Save Changes</Button>
+              <Button variant="outline" style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)}>Cancel</Button>
+            </div>
+          }
+        >
+          <div className="space-y-4">
+            <p className="text-gray-700">This dialog uses props for flexible content layout.</p>
+            <div className="bg-blue-50 p-4 rounded-lg">
+              <p className="text-blue-800">You can put any content here including forms, lists, or other components.</p>
+            </div>
+          </div>
+        </Dialog>
+      </div>
+    );
+  },
+};
+
+export const DifferentSizes: Story = {
+  render: () => {
+    const [isSmallOpen, setSmallOpen] = useState(false);
+    const [isLargeOpen, setLargeOpen] = useState(false);
+
+    return (
+      <div className="space-x-2">
+        <Button onClick={() => setSmallOpen(true)}>Small Dialog</Button>
+        <Button onClick={() => setLargeOpen(true)}>Large Dialog</Button>
+
+        <Dialog
+          open={isSmallOpen}
+          onOpenChange={setSmallOpen}
+          options={{
+            title: 'Small Dialog',
+            message: 'This is a small dialog.',
+            size: 'sm',
+            actions: [{ label: 'OK', variant: 'solid' }],
+          }}
+        />
+
+        <Dialog
+          open={isLargeOpen}
+          onOpenChange={setLargeOpen}
+          options={{
+            title: 'Large Dialog',
+            message: 'This is a large dialog with more space for content.',
+            size: '4xl',
+            actions: [{ label: 'OK', variant: 'solid' }],
+          }}
+        />
+      </div>
+    );
+  },
+};
+
+export const DisableOutsideClick: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Show Modal Dialog</Button>
+        <Dialog
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          disableOutsideClickToClose={true}
+          options={{
+            title: 'Modal Dialog',
+            message: 'This dialog cannot be closed by clicking outside. Use the buttons or ESC key.',
+            actions: [{ label: 'Close', variant: 'solid' }],
+          }}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithInteractiveComponents: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selectedOption, setSelectedOption] = useState('Option 1');
+    const [autocompleteValue, setAutocompleteValue] = useState('' as AutocompleteOption);
+
+    const dropdownOptions = [
+      { label: 'Option 1', onClick: () => setSelectedOption('Option 1'), key: '1' },
+      { label: 'Option 2', onClick: () => setSelectedOption('Option 2'), key: '2' },
+      { label: 'Option 3', onClick: () => setSelectedOption('Option 3'), key: '3' },
+      {
+        group: 'Advanced Options',
+        key: 'group-1',
+        items: [
+          { label: 'Advanced Option A', icon: 'Settings', onClick: () => setSelectedOption('Advanced Option A'), key: '1' },
+          { label: 'Advanced Option B', icon: 'Star', onClick: () => setSelectedOption('Advanced Option B'), key: '2' },
+        ],
+      },
+    ];
+
+    return (
+      <div>
+        <Button onClick={() => setIsOpen(true)}>Show Settings Dialog</Button>
+        <Dialog
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          options={{
+            title: () => <h3 className="text-2xl font-semibold text-ink-gray-9">Settings Dialog</h3>
+          }}
+          actions={
+            <div className="flex space-x-2">
+              <Button variant="solid" style={{ cursor: "pointer" }}  onClick={() => setIsOpen(false)}>Save Settings</Button>
+              <Button variant="outline" style={{ cursor: "pointer" }} onClick={() => setIsOpen(false)}>Cancel</Button>
+            </div>
+          }
+        >
+          <div className="space-y-6 text-base">
+            <p className="text-gray-700">This dialog contains interactive elements to test proper layering.</p>
+            <Autocomplete
+              options={[
+                { label: 'Option A', value: 'A' },
+                { label: 'Option B', value: 'B' },
+                { label: 'Option C', value: 'C' },
+              ]}
+              placeholder="Type to search..."
+              value={autocompleteValue ?? ''}
+              onChange={(_value) => setAutocompleteValue(_value as AutocompleteOption)}
+            />
+            <div className="space-y-3">
+              <label className="block text-sm font-medium text-gray-700">Select an option:</label>
+              <Dropdown options={dropdownOptions} placement="left">
+                <Button variant="outline" suffix={<FeatherIcon name="chevron-down"  className="h-4 w-4 text-gray-500" />}>
+                  {selectedOption}
+                </Button>
+              </Dropdown>
+            </div>
+            <div className="bg-gray-50 text-sm p-4 text-gray-600 rounded-lg">
+              <p><strong>Selected value:</strong> {selectedOption}</p>
+              <p className="mt-1">Interactive components should work properly within dialogs.</p>
+            </div>
+          </div>
+        </Dialog>
+      </div>
+    );
+  },
+};

--- a/packages/frappe-components/src/components/dialog/dialog.tsx
+++ b/packages/frappe-components/src/components/dialog/dialog.tsx
@@ -1,0 +1,230 @@
+import React, { useMemo } from "react";
+import { Root, Portal, Overlay, Content, Close, Description, Title} from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import clsx from "clsx";
+import { Button } from "../button";
+import FeatherIcon from "../featherIcon";
+import { DialogActionButton, type DialogAction } from "./dialogActionButton";
+import "./dialog.css";
+
+export interface DialogOptions {
+  title?: (() => React.ReactNode) | string;
+  message?: string;
+  size?:
+    | "xs"
+    | "sm"
+    | "md"
+    | "lg"
+    | "xl"
+    | "2xl"
+    | "3xl"
+    | "4xl"
+    | "5xl"
+    | "6xl"
+    | "7xl";
+  position?: "center" | "top";
+  icon?: {
+    name: string;
+    appearance?: "info" | "success" | "warning" | "danger";
+  };
+  actions?: DialogAction[];
+}
+
+export interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  options?: DialogOptions;
+  disableOutsideClickToClose?: boolean;
+  onAfterLeave?: () => void;
+  children?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export const Dialog = ({
+  open,
+  onOpenChange,
+  options = {},
+  disableOutsideClickToClose = false,
+  onAfterLeave,
+  children,
+  actions: customActions,
+}: DialogProps) => {
+  const {
+    title,
+    message,
+    size,
+    position = "center",
+    icon: iconProp,
+    actions = [],
+  } = options;
+
+  const handleInteractOutside = (e: Event) => {
+    if (disableOutsideClickToClose) {
+      e.preventDefault();
+    }
+  };
+
+  const closeDialog = () => onOpenChange(false);
+
+  const icon = useMemo(() => {
+    if (!iconProp) return null;
+    return typeof iconProp === "string" ? { name: iconProp } : iconProp;
+  }, [iconProp]);
+
+  const dialogPositionClasses = useMemo(
+    () => ({
+      "justify-center": position === "center",
+      "pt-[20vh]": position === "top",
+    }),
+    [position]
+  );
+
+  const dialogIconBgClasses = useMemo(() => {
+    if (!icon?.appearance) {
+      return "bg-surface-gray-2";
+    }
+
+    if (icon.appearance === "warning") {
+      return "bg-surface-amber-2";
+    }
+
+    if (icon.appearance === "info") {
+      return "bg-surface-gray-2";
+    }
+
+    if (icon.appearance === "danger") {
+      return "bg-surface-red-2";
+    }
+
+    if (icon.appearance === "success") {
+      return "bg-surface-green-2";
+    }
+  }, [icon]);
+
+  const dialogIconClasses = useMemo(() => {
+    if (!icon?.appearance) {
+      return "text-ink-gray-5";
+    }
+
+    if (icon.appearance === "warning") {
+      return "text-ink-amber-3";
+    }
+
+    if (icon.appearance === "info") {
+      return "text-ink-blue-3";
+    }
+
+    if (icon.appearance === "danger") {
+      return "text-ink-red-4";
+    }
+
+    if (icon.appearance === "success") {
+      return "text-ink-green-3";
+    }
+  }, [icon]);
+
+  return (
+    <Root open={open} onOpenChange={onOpenChange}>
+      <Portal>
+        <Overlay
+          className="dialog-overlay fixed inset-0 bg-black-overlay-200 backdrop-filter backdrop-blur-[12px] overflow-y-auto"
+          data-dialog={'dialog'}
+          onAnimationEnd={() => !open && onAfterLeave?.()}
+        >
+          <div
+            className={clsx(
+              "flex min-h-screen flex-col items-center px-4 py-4 text-center",
+              dialogPositionClasses
+            )}
+          >
+            <Content
+              className={clsx(
+                "dialog-content my-8 inline-block w-full transform overflow-hidden rounded-xl bg-surface-modal text-left align-middle shadow-xl",
+                {
+                  "max-w-7xl": size === "7xl",
+                  "max-w-6xl": size === "6xl",
+                  "max-w-5xl": size === "5xl",
+                  "max-w-4xl": size === "4xl",
+                  "max-w-3xl": size === "3xl",
+                  "max-w-2xl": size === "2xl",
+                  "max-w-xl": size === "xl",
+                  "max-w-lg": size === "lg" || !size,
+                  "max-w-md": size === "md",
+                  "max-w-sm": size === "sm",
+                  "max-w-xs": size === "xs",
+                }
+              )}
+              onEscapeKeyDown={closeDialog}
+              onInteractOutside={handleInteractOutside}
+            >
+              <div className="bg-surface-modal px-4 pb-6 pt-5 sm:px-6">
+                <div className="flex">
+                  <div className="w-full flex-1">
+                    <div className="mb-6 flex items-center justify-between">
+                      <div className="flex items-center space-x-2">
+                        {icon && (
+                          <div
+                            className={clsx(
+                              "flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full",
+                              dialogIconBgClasses
+                            )}
+                          >
+                            <FeatherIcon
+                              name={icon.name}
+                              className={clsx("h-4 w-4", dialogIconClasses)}
+                              aria-hidden="true"
+                            />
+                          </div>
+                        )}
+                        <Title asChild>
+                          {typeof title === "string" ? (
+                            <h3 className="text-2xl font-semibold leading-6 text-ink-gray-9">
+                            { title || "Untitled"}
+                          </h3>
+                          ): title && title()}
+                        </Title>
+                      </div>
+                      <Close asChild>
+                        <Button style={{ cursor: "pointer" }} variant="ghost" onClick={closeDialog}>
+                          <X className="h-4 w-4 text-ink-gray-9" />
+                        </Button>
+                      </Close>
+                    </div>
+
+                    {children
+                      ? children
+                      : message && (
+                          <Description asChild>
+                            <p className="text-p-base text-ink-gray-7">
+                              {message}
+                            </p>
+                          </Description>
+                        )}
+                  </div>
+                </div>
+              </div>
+
+              {(actions.length > 0 || customActions) && (
+                <div className="px-4 pb-7 pt-4 sm:px-6">
+                  {customActions ? (
+                    customActions
+                  ) : (
+                    <div className="space-y-2">
+                      {actions.map((action) => (
+                        <DialogActionButton
+                          key={action.label}
+                          action={action}
+                          close={closeDialog}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </Content>
+          </div>
+        </Overlay>
+      </Portal>
+    </Root>
+  );
+};

--- a/packages/frappe-components/src/components/dialog/dialogActionButton.tsx
+++ b/packages/frappe-components/src/components/dialog/dialogActionButton.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Button, type ButtonProps } from '../button';
+
+export interface DialogActionContext {
+  close: () => void;
+}
+
+
+export type DialogAction = Omit<ButtonProps, 'onClick'> & {
+  label: string;
+  onClick?: (context: DialogActionContext) => void | Promise<void>;
+};
+
+interface DialogActionButtonProps {
+  action: DialogAction;
+  close: () => void;
+}
+
+export const DialogActionButton = ({ action, close }: DialogActionButtonProps) => {
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (!action.onClick) {
+      close();
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await action.onClick({ close });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Button
+      {...action}
+      style={{ cursor: "pointer" }}
+      extraClassName="w-full"
+      disabled={action.disabled || loading}
+      loading={loading}
+      onClick={handleClick}
+    >
+      {action.label}
+    </Button>
+  );
+};

--- a/packages/frappe-components/src/components/dialog/index.ts
+++ b/packages/frappe-components/src/components/dialog/index.ts
@@ -1,0 +1,1 @@
+export { default as Avatar, type AvatarProps } from './dialog'

--- a/packages/frappe-components/src/components/formControl/formControl.tsx
+++ b/packages/frappe-components/src/components/formControl/formControl.tsx
@@ -49,7 +49,7 @@ const FormControl: React.FC<FormControlProps> = ({
         return (
           <Autocomplete
             options={controlAttrs.options as AutocompleteOption[]}
-            modelValue={controlAttrs.modelValue}
+            value={controlAttrs.modelValue}
             {...controlAttrs}
           />
         );


### PR DESCRIPTION
## Description

The primary goal of this PR is to provide interactive, real-world examples of the `Dialog` component's functionality. This replaces the previous Vue-based stories (`Histoire`) with the standard React Storybook (`CSF3`) format.

The following scenarios have been added:

* **Basic Confirmation**: A standard dialog with a title, message, icon, and an async action button.
* **Custom Content**: Demonstrates how to use props like `title`, `children`, and `actions` to inject custom JSX, providing flexible and complex layouts.
* **Different Sizes**: Showcases the `size` option by rendering small and large variants of the dialog.
* **Disabled Outside Click**: Tests the `disableOutsideClickToClose` prop to create a true modal experience.
* **Interactive Components**: A complex example featuring other components like `Dropdown` and `Autocomplete` inside the dialog to ensure proper event handling, focus management, and layering.

## Testing Instructions

1.  Navigate to the Storybook environment.
2.  In the sidebar, go to **Components > Dialog**.
3.  Review each of the new stories:
    * `BasicConfirmation`
    * `CustomContent`
    * `DifferentSizes`
    * `DisableOutsideClick`
    * `WithInteractiveComponents`
4.  Interact with each story to open the dialogs.
5.  Verify that each dialog behaves as described and matches its intended design.
6.  Confirm that interactive elements within the "WithInteractiveComponents" story (like dropdowns and autocomplete) are fully functional.