### PR TITLE
Feature: Add Progress component

### DIFF
--- a/packages/frappe-components/src/components/progress/index.ts
+++ b/packages/frappe-components/src/components/progress/index.ts
@@ -1,0 +1,2 @@
+export { default as Progress } from "./progress";
+export type { ProgressProps } from "./types";

--- a/packages/frappe-components/src/components/progress/progress.stories.tsx
+++ b/packages/frappe-components/src/components/progress/progress.stories.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Progress from "./progress";
+import { Story, Variant } from "../Story";
+
+const meta: Meta<typeof Progress> = {
+  title: "Components/Progress",
+  tags: ["autodocs"],
+  component: Progress,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    value: {
+      control: { type: "range", min: 0, max: 100 },
+      description: "Current progress value (0-100)",
+      table: { category: "Props" },
+    },
+    size: {
+      control: { type: "select" },
+      options: ["sm", "md", "lg", "xl"],
+      description: "Progress bar height/size",
+      table: { category: "Props" },
+    },
+    label: {
+      control: "text",
+      description: "Optional label displayed above the bar",
+      table: { category: "Props" },
+    },
+    hint: {
+      control: false,
+      description: "Custom hint node (slot-like)",
+      table: { category: "Props" },
+    },
+    intervals: {
+      control: "boolean",
+      description: "Enable interval/step mode",
+      table: { category: "Props" },
+    },
+    intervalCount: {
+      control: { type: "number", min: 1, max: 20 },
+      description: "Number of intervals/steps (if intervals enabled)",
+      table: { category: "Props" },
+    },
+    className: {
+      control: "text",
+      description: "Custom CSS classes for the container",
+      table: { category: "Props" },
+    },
+  },
+};
+export default meta;
+
+type ProgressStory = StoryObj<typeof Progress>;
+
+const sizes = ["sm", "md", "lg", "xl"] as const;
+
+export const Label: ProgressStory = {
+  render: (args: React.ComponentProps<typeof Progress>) => (
+    <Story layout={{ type: "grid", width: 500 }}>
+      <Variant title="Label">
+        <Progress {...args} label="Progress" />
+      </Variant>
+    </Story>
+  ),
+  args: {
+    value: 50,
+    size: "sm",
+  },
+  argTypes: {
+    value: { control: { type: "range", min: 0, max: 100 }, name: "Value" },
+    size: { control: { type: "select" }, options: sizes, name: "Size" },
+  },
+};
+
+export const Hint: ProgressStory = {
+  render: (args: React.ComponentProps<typeof Progress>) => (
+    <Story layout={{ type: "grid", width: 500 }}>
+      <Variant title="Hint">
+        <Progress
+          {...args}
+          label="Progress"
+          hint={
+            <span className="text-base font-medium text-ink-gray-4">
+              {args.value}%
+            </span>
+          }
+        />
+      </Variant>
+    </Story>
+  ),
+  args: {
+    value: 50,
+    size: "sm",
+  },
+  argTypes: Label.argTypes,
+};
+
+export const Intervals: ProgressStory = {
+  render: (args: React.ComponentProps<typeof Progress>) => (
+    <Story layout={{ type: "grid", width: 500 }}>
+      <Variant title="Intervals">
+        <Progress {...args} label="Progress" intervals intervalCount={5} />
+      </Variant>
+    </Story>
+  ),
+  args: {
+    value: 50,
+    size: "sm",
+  },
+  argTypes: Label.argTypes,
+};

--- a/packages/frappe-components/src/components/progress/progress.tsx
+++ b/packages/frappe-components/src/components/progress/progress.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { ProgressProps } from "./types";
+
+const MIN_VALUE = 0;
+const MAX_VALUE = 100;
+
+const sizeHeight: Record<NonNullable<ProgressProps["size"]>, string> = {
+  sm: "h-0.5",
+  md: "h-1",
+  lg: "h-2",
+  xl: "h-3",
+};
+
+const Progress: React.FC<ProgressProps> = ({
+  value,
+  size = "sm",
+  label = "",
+  hint,
+  intervals = false,
+  intervalCount = 6,
+  className = "",
+}) => {
+  // Classes for the progress bar container
+  const indicatorContainerClasses = [
+    sizeHeight[size],
+    intervals ? "flex space-x-1" : "relative bg-surface-gray-2",
+    "overflow-hidden rounded-xl",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // How many intervals are filled
+  const filledIntervalCount =
+    value > MAX_VALUE
+      ? intervalCount
+      : Math.round((value / MAX_VALUE) * intervalCount);
+
+  return (
+    <div className="w-full flex flex-col gap-2.5">
+      {(label || hint) && (
+        <div className="flex items-baseline justify-between">
+          {label ? (
+            <span className="text-base font-medium text-ink-gray-8">
+              {label}
+            </span>
+          ) : (
+            <span />
+          )}
+
+          {hint && <span className="self-end">{hint}</span>}
+        </div>
+      )}
+
+      <div
+        className={indicatorContainerClasses}
+        aria-valuemax={MAX_VALUE}
+        aria-valuemin={MIN_VALUE}
+        aria-valuenow={value}
+        role="progressbar"
+      >
+        {!intervals ? (
+          <div
+            className="h-full bg-surface-gray-7"
+            style={{ width: `${value}%` }}
+          />
+        ) : (
+          Array.from({ length: intervalCount }, (_, i) => (
+            <div
+              key={i}
+              className={`h-full w-full ${
+                i < filledIntervalCount
+                  ? "bg-surface-gray-7"
+                  : "bg-surface-gray-2"
+              }`}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Progress;

--- a/packages/frappe-components/src/components/progress/types.ts
+++ b/packages/frappe-components/src/components/progress/types.ts
@@ -1,0 +1,9 @@
+export type ProgressProps = {
+  value: number;
+  size?: "sm" | "md" | "lg" | "xl";
+  label?: string;
+  hint?: React.ReactNode;
+  intervals?: boolean;
+  intervalCount?: number;
+  className?: string;
+};


### PR DESCRIPTION
This pull request introduces a new `Progress` component to the `frappe-components` package, along with its type definitions and Storybook stories for documentation and testing. The main changes include the implementation of the component, its props typing, and comprehensive Storybook stories covering different usage scenarios.

**New Progress Component Implementation:**

* Added the `Progress` React component with support for customizable size, value, optional label, hint, interval/step mode, and custom class names (`progress.tsx`).
* Defined the `ProgressProps` type to strongly type the component's props, including support for intervals and custom hints (`types.ts`).
* Exported the `Progress` component and its props type from the index file for easier imports (`index.ts`).

**Storybook Integration:**

* Added comprehensive Storybook stories demonstrating the `Progress` component's features, including label, hint, and intervals/step mode, with interactive controls for all props (`progress.stories.tsx`).