### PR TITLE
Refactor: Update font to 'Inter'

### DIFF
--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Reddit+Sans:ital,wght@0,200..900;1,200..900&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 @import "tailwindcss";
 
 @config '../../../tailwind.config.cjs';

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,7 +8,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ["Reddit Sans", "ui-sans-serif", "system-ui", "sans-serif"],
+        sans: ["Inter", "ui-sans-serif", "system-ui", "sans-serif"],
       },
       colors: {
         inherit: "var(--color-inherit)",


### PR DESCRIPTION
This pull request updates the default sans-serif font used across the UI from "Reddit Sans" to "Inter". The change updates both the font import in the CSS and the Tailwind font family configuration.

**Theme and font updates:**

* Changed the Google Fonts import in `theme.css` to use the "Inter" font instead of "Reddit Sans".
* Updated the Tailwind `fontFamily.sans` configuration in `tailwind.config.cjs` to use "Inter" as the primary sans-serif font.