### PR TITLE
Fix: Make docs source type dynamic

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
@@ -40,9 +40,7 @@ const meta: Meta<typeof Autocomplete> = {
   title: "Components/Autocomplete",
   component: Autocomplete,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     value: {
       control: "object",

--- a/packages/frappe-ui-react/src/components/avatar/avatar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/avatar/avatar.stories.tsx
@@ -5,9 +5,7 @@ import type { StoryObj } from "@storybook/react-vite";
 export default {
   title: "Components/Avatar",
   component: Avatar,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     size: {
       control: {

--- a/packages/frappe-ui-react/src/components/badge/badge.stories.tsx
+++ b/packages/frappe-ui-react/src/components/badge/badge.stories.tsx
@@ -37,9 +37,7 @@ export default {
       description: "Alternative to label prop, rendered as children",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof Badge>;
 

--- a/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -21,9 +21,7 @@ export default {
         "Function to render a suffix element for each breadcrumb item.",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof Breadcrumbs>;
 

--- a/packages/frappe-ui-react/src/components/button/button.stories.tsx
+++ b/packages/frappe-ui-react/src/components/button/button.stories.tsx
@@ -71,9 +71,7 @@ export default {
       description: "Right side icon for the button",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
 } as Meta<typeof Button>;
 
 const ButtonTemplate: StoryObj<ButtonProps> = {

--- a/packages/frappe-ui-react/src/components/calendar/calendar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/calendar/calendar.stories.tsx
@@ -7,9 +7,7 @@ import TabButtons from "../tabButtons";
 const meta: Meta<typeof Calendar> = {
   title: "Components/Calendar",
   component: Calendar,
-  parameters: {
-    layout: "fullscreen",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "fullscreen" },
   argTypes: {
     config: {
       createNewEvent: { action: "create" },

--- a/packages/frappe-ui-react/src/components/charts/chart.stories.tsx
+++ b/packages/frappe-ui-react/src/components/charts/chart.stories.tsx
@@ -196,9 +196,7 @@ const funnelConfig: FunnelChartConfig = {
 
 const meta: Meta<typeof NumberChart> = {
   title: "Components/Charts",
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     config: {
       control: "object",
@@ -215,7 +213,7 @@ const meta: Meta<typeof NumberChart> = {
 export default meta;
 
 export const NumberCharts: StoryObj<NumberChartProps> = {
-  render: (_args) => (
+  render: () => (
     <div className="flex gap-2 p-4">
       <NumberChart config={numberChart1Config} />
       <NumberChart config={numberChart2Config} />

--- a/packages/frappe-ui-react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/frappe-ui-react/src/components/checkbox/checkbox.stories.tsx
@@ -8,9 +8,7 @@ import { CheckboxProps } from "./types";
 export default {
   title: "Components/Checkbox",
   component: Checkbox,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     label: {
       control: "text",

--- a/packages/frappe-ui-react/src/components/circularProgressBar/circularProgressBar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/circularProgressBar/circularProgressBar.stories.tsx
@@ -38,9 +38,7 @@ export default {
       description: "Visual variant of the progress bar.",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof CircularProgressBar>;
 

--- a/packages/frappe-ui-react/src/components/combobox/combobox.stories.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.stories.tsx
@@ -7,9 +7,7 @@ const meta: Meta<typeof Combobox> = {
   title: "Components/Combobox",
   tags: ["autodocs"],
   component: Combobox,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     options: {
       control: "object",

--- a/packages/frappe-ui-react/src/components/datePicker/datePicker.stories.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/datePicker.stories.tsx
@@ -8,6 +8,7 @@ const meta: Meta = {
   tags: ["autodocs"],
   component: DatePicker,
   parameters: {
+    docs: { source: { type: "dynamic" } },
     layout: "centered",
     docs: { autodocs: true },
   },

--- a/packages/frappe-ui-react/src/components/dialog/dialog.stories.tsx
+++ b/packages/frappe-ui-react/src/components/dialog/dialog.stories.tsx
@@ -22,9 +22,7 @@ const meta: Meta<typeof Dialog> = {
       </div>
     ),
   ],
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     open: {

--- a/packages/frappe-ui-react/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/frappe-ui-react/src/components/dropdown/dropdown.stories.tsx
@@ -28,9 +28,7 @@ export default {
       description: "Custom trigger element for the dropdown.",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof Dropdown>;
 

--- a/packages/frappe-ui-react/src/components/errorMessage/errorMessage.stories.tsx
+++ b/packages/frappe-ui-react/src/components/errorMessage/errorMessage.stories.tsx
@@ -12,9 +12,7 @@ export default {
         "The error message to display, can be a string or an Error object.",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof ErrorMessage>;
 

--- a/packages/frappe-ui-react/src/components/fileUploader/fileUploader.stories.tsx
+++ b/packages/frappe-ui-react/src/components/fileUploader/fileUploader.stories.tsx
@@ -6,9 +6,7 @@ import FileUploader from "./fileuploader";
 const meta: Meta<typeof FileUploader> = {
   title: "Components/FileUploader",
   component: FileUploader,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     fileTypes: {

--- a/packages/frappe-ui-react/src/components/formControl/formControl.stories.tsx
+++ b/packages/frappe-ui-react/src/components/formControl/formControl.stories.tsx
@@ -7,9 +7,7 @@ import { useState } from "react";
 const meta: Meta<typeof FormControl> = {
   title: "Components/FormControl",
   component: FormControl,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     variant: {

--- a/packages/frappe-ui-react/src/components/password/password.stories.tsx
+++ b/packages/frappe-ui-react/src/components/password/password.stories.tsx
@@ -21,9 +21,7 @@ export default {
     },
     prefix: { description: "Element to display at the start of the input." },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
 } as Meta<typeof Password>;
 

--- a/packages/frappe-ui-react/src/components/popover/popover.stories.tsx
+++ b/packages/frappe-ui-react/src/components/popover/popover.stories.tsx
@@ -7,9 +7,7 @@ const meta: Meta<typeof Popover> = {
   title: "Components/Popover",
   component: Popover,
   tags: ["autodocs"],
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     show: {
       control: "boolean",

--- a/packages/frappe-ui-react/src/components/progress/progress.stories.tsx
+++ b/packages/frappe-ui-react/src/components/progress/progress.stories.tsx
@@ -6,9 +6,7 @@ const meta: Meta<typeof Progress> = {
   title: "Components/Progress",
   tags: ["autodocs"],
   component: Progress,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     value: {
       control: { type: "range", min: 0, max: 100 },

--- a/packages/frappe-ui-react/src/components/rating/rating.stories.tsx
+++ b/packages/frappe-ui-react/src/components/rating/rating.stories.tsx
@@ -7,9 +7,7 @@ const meta: Meta<typeof Rating> = {
   title: "Components/Rating",
   tags: ["autodocs"],
   component: Rating,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     value: {
       control: { type: "number", min: 0, max: 5 },

--- a/packages/frappe-ui-react/src/components/select/select.stories.tsx
+++ b/packages/frappe-ui-react/src/components/select/select.stories.tsx
@@ -6,9 +6,7 @@ import Select from "./select";
 export default {
   title: "Components/Select",
   component: Select,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     size: {

--- a/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
@@ -20,9 +20,7 @@ import Sidebar from "./sidebar";
 const meta: Meta<typeof Sidebar> = {
   title: "Components/Sidebar",
   tags: ["autodocs"],
-  parameters: {
-    layout: "padded",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "padded" },
   argTypes: {
     header: {
       control: "object",

--- a/packages/frappe-ui-react/src/components/spinner/spinner.stories.tsx
+++ b/packages/frappe-ui-react/src/components/spinner/spinner.stories.tsx
@@ -4,9 +4,7 @@ import Spinner from "./spinner";
 const meta: Meta<typeof Spinner> = {
   title: "Components/Spinner",
   component: Spinner,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   decorators: [
     (Story) => (
       <div

--- a/packages/frappe-ui-react/src/components/switch/switch.stories.tsx
+++ b/packages/frappe-ui-react/src/components/switch/switch.stories.tsx
@@ -8,9 +8,7 @@ const meta: Meta<typeof Switch> = {
   title: "Components/Switch",
   tags: ["autodocs"],
   component: Switch,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
 };
 export default meta;
 

--- a/packages/frappe-ui-react/src/components/tabButtons/index.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tabButtons/index.stories.tsx
@@ -20,9 +20,7 @@ const meta: Meta<typeof TabButtons> = {
       description: "Function called when the selected tab changes.",
     },
   },
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   component: TabButtons,
 };
 

--- a/packages/frappe-ui-react/src/components/tabs/tabs.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tabs/tabs.stories.tsx
@@ -6,9 +6,7 @@ const meta: Meta<typeof Tabs> = {
   title: "Components/Tabs",
   tags: ["autodocs"],
   component: Tabs,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     tabs: {
       control: false,

--- a/packages/frappe-ui-react/src/components/textEditor/textEditor.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/textEditor.stories.tsx
@@ -5,9 +5,7 @@ import { useState } from "react";
 const meta: Meta<typeof TextEditor> = {
   title: "Components/TextEditor",
   component: TextEditor,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   argTypes: {
     allowImageUpload: {
       control: "boolean",

--- a/packages/frappe-ui-react/src/components/textInput/textInput.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textInput/textInput.stories.tsx
@@ -8,9 +8,7 @@ import FeatherIcon from "../featherIcon";
 export default {
   title: "Components/TextInput",
   component: TextInput,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     type: {

--- a/packages/frappe-ui-react/src/components/textarea/textarea.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textarea/textarea.stories.tsx
@@ -6,9 +6,7 @@ import TextArea from "./textarea";
 export default {
   title: "Components/TextArea",
   component: TextArea,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     label: { control: "text", description: "Label for the textarea" },

--- a/packages/frappe-ui-react/src/components/toast/toast.stories.tsx
+++ b/packages/frappe-ui-react/src/components/toast/toast.stories.tsx
@@ -6,6 +6,8 @@ import { Button } from "../button";
 
 export default {
   title: "Components/Toast",
+  parameters: { docs: { source: { type: "code" } }, layout: "centered" },
+	tags: ["autodocs"],
   decorators: [
     (Story) => (
       <ToastProvider>
@@ -15,7 +17,7 @@ export default {
   ],
 } as Meta<typeof ToastProvider>;
 
-const ToastTriggerComponent = () => {
+export const Default = () => {
   const toast = useToasts();
 
   const handlePromise = () => {
@@ -50,5 +52,3 @@ const ToastTriggerComponent = () => {
     </div>
   );
 };
-
-export const Default = () => <ToastTriggerComponent />;

--- a/packages/frappe-ui-react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tooltip/tooltip.stories.tsx
@@ -6,9 +6,7 @@ import { Button } from "../button";
 const meta: Meta<typeof Tooltip> = {
   title: "Components/Tooltip",
   component: Tooltip,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
   tags: ["autodocs"],
   argTypes: {
     placement: {

--- a/packages/frappe-ui-react/src/components/tree/tree.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tree/tree.stories.tsx
@@ -5,9 +5,7 @@ const meta: Meta<typeof Tree> = {
   title: "Components/Tree",
   tags: ["autodocs"],
   component: Tree,
-  parameters: {
-    layout: "centered",
-  },
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
 };
 export default meta;
 


### PR DESCRIPTION
This pull request updates the Storybook configuration for many component story files in the `frappe-ui-react` package. The main change is the addition of dynamic source documentation to the `parameters` for each story, ensuring that the source code shown in Storybook is always up-to-date and dynamically generated. This improves the developer experience and documentation quality across all component stories.

Storybook documentation enhancements:

* Updated the `parameters` object in all component story files (e.g., `autoComplete.stories.tsx`, `avatar.stories.tsx`, `badge.stories.tsx`, etc.) to include `{ docs: { source: { type: "dynamic" } }, layout: "centered" }` or `{ docs: { source: { type: "dynamic" } }, layout: "fullscreen" }`, replacing the previous static layout-only configuration. 
* For `toast.stories.tsx` value `{ docs: { source: { type: "code" } }, layout: "centered" }` is set because of non JSX logic.