### PR TITLE
Fixs image with empty source for placeholder in Autocomplete Prefix Slot

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
@@ -147,13 +147,15 @@ export const SingleOptionWithPrefixSlots: Story = {
         <Autocomplete
           {...args}
           value={value}
-          prefix={(value) => (
+          prefix={(value) => ( 
+            value?.image &&
             <img
               src={value?.image ?? ""}
               className="mr-2 h-4 w-4 rounded-full"
             />
           )}
           itemPrefix={(value) => (
+            value?.image &&
             <img
               src={value?.image ?? ""}
               className="ml-2 h-4 w-4 rounded-full"


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
In Autocomplete Prefix Slot for placeholder image is rendered with empty source.

## Relevant Technical Choices

<!-- Please describe your changes. -->
Fix ensures that the image element is not rendered when an empty source is provided.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->
Before:
<img width="625" height="316" alt="Screenshot 2025-11-03 at 1 56 53 PM" src="https://github.com/user-attachments/assets/0962524a-9e9d-4937-a135-9bea52f13494" />


After:
<img width="625" height="316" alt="Screenshot 2025-11-03 at 1 55 44 PM" src="https://github.com/user-attachments/assets/d82782ac-37c9-4a8f-b98b-8c54a63c92ea" />

---



## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
