### PR TITLE
Fix: Autocomplete width

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -295,7 +295,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   );
 
   return (
-    <div style={{ width: "100px" }}>
+    <div className="min-w-24 w-full">
       <Combobox
         value={selectedComboboxValue}
         onChange={handleComboboxChange}

--- a/packages/frappe-ui-react/src/components/formControl/formControl.stories.tsx
+++ b/packages/frappe-ui-react/src/components/formControl/formControl.stories.tsx
@@ -156,11 +156,13 @@ export const Autocomplete: Story = {
   render: (args) => {
     const [value, setValue] = useState("");
     return (
-      <FormControl
-        {...args}
-        value={value}
-        onChange={(_value: string) => setValue(_value)}
-      />
+      <div className="w-40">
+        <FormControl
+          {...args}
+          value={value}
+          onChange={(_value: string) => setValue(_value)}
+        />
+      </div>
     );
   },
 };


### PR DESCRIPTION
This pull request contains minor UI updates to improve the layout and responsiveness of the `Autocomplete` and `FormControl` components in the Frappe UI React package.

Layout and styling improvements:

* Changed the wrapper `div` in `autoComplete.tsx` to use Tailwind CSS utility classes (`min-w-24 w-full`) for better width control and responsiveness, replacing the fixed inline width style.
* Added a wrapper `div` with a fixed width (`w-40`) to the `Autocomplete` story in `formControl.stories.tsx` to ensure consistent display in Storybook.