### PR TITLE
[TextArea] Add Disabled story to Storybook

### DIFF
--- a/packages/frappe-ui-react/src/components/textarea/textarea.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textarea/textarea.stories.tsx
@@ -80,3 +80,13 @@ export const OutlineVariant = {
     value: "",
   },
 };
+
+export const Disabled = {
+  ...Template,
+  args: {
+    placeholder: "Disabled textarea",
+    variant: "outline",
+    value: "",
+    disabled: true,
+  },
+};


### PR DESCRIPTION
## Description

Added a missing `Disabled` story for the TextArea component to showcase the disabled state in Storybook. The component already supports the `disabled` prop but lacked a dedicated story to demonstrate it.

## Relevant Technical Choices

- Followed the existing story pattern used by `SubtleVariant` and `OutlineVariant`
- Used the shared `Template` to maintain consistency
- Set `disabled: true` to showcase the disabled state

## Testing Instructions

1. Run `npm run storybook`
2. Navigate to **Components → TextArea → Disabled**
3. Verify the textarea appears in a disabled state (grayed out, not interactive)
4. Confirm hover and focus states don't apply when disabled

## Additional Information:

This is a small documentation improvement to help developers understand how to use the disabled prop.

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- ~This code is covered by unit tests to verify that it works as intended.~ NA
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

