### PR TITLE
Fix: Dark mode colors 

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
@@ -158,7 +158,7 @@ export const SingleOptionWithPrefixSlots: Story = {
             value?.image &&
             <img
               src={value?.image ?? ""}
-              className="ml-2 h-4 w-4 rounded-full"
+              className="h-4 w-4 rounded-full"
             />
           )}
           onChange={(_value) => {

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -138,7 +138,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
         </ComboboxButton>
         <ComboboxOptions
           className={`
-            absolute z-[100] mt-1 px-1.5 py-1.5 w-full bg-surface-white border border-surface-gray-2 rounded-lg shadow-xl min-w-[160px] max-h-50 animate-fade-in overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:'none'] [-webkit-overflow-scrolling:'touch']
+            absolute z-[100] mt-1 px-1.5 py-1.5 w-full bg-surface-modal border border-surface-gray-2 rounded-lg shadow-xl min-w-[160px] max-h-50 animate-fade-in overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none] [-ms-overflow-style:'none'] [-webkit-overflow-scrolling:'touch']
           `}
         >
           {filteredOptions.length === 0 && (

--- a/packages/frappe-ui-react/src/components/switch/switch.tsx
+++ b/packages/frappe-ui-react/src/components/switch/switch.tsx
@@ -39,11 +39,11 @@ const Switch: React.FC<SwitchProps> = ({
     "disabled:cursor-not-allowed disabled:bg-surface-gray-3",
     value
       ? "bg-surface-gray-7 enabled:hover:bg-surface-gray-6 active:bg-surface-gray-5"
-      : "bg-surface-gray-4 enabled:hover:bg-gray-400 active:bg-gray-500",
+      : "bg-surface-gray-4 enabled:hover:bg-gray-400 active:bg-gray-500 dark:enabled:hover:bg-dark-gray-100 dark:active:bg-dark-gray-200",
     switchType === SwitchVariant.ONLY_LABEL &&
       (value
         ? "group-hover:enabled:bg-surface-gray-6"
-        : "group-hover:enabled:bg-gray-400"),
+        : "group-hover:enabled:bg-gray-400 dark:group-hover:enabled:bg-dark-gray-100"),
     size === "md" ? "h-5 w-8 border-[3px]" : "h-4 w-[26px] border-2",
   ].join(" ");
 

--- a/packages/frappe-ui-react/src/components/themeShowCase/ThemeShowcase.css
+++ b/packages/frappe-ui-react/src/components/themeShowCase/ThemeShowcase.css
@@ -484,10 +484,6 @@
   color: var(--color-ink-gray-8);
 }
 
-.dark .default-token-note p {
-  color: var(--color-ink-gray-1);
-}
-
 /* Responsive adjustments for default tokens */
 @media (max-width: 768px) {
   .default-token-grid {

--- a/packages/frappe-ui-react/src/components/themeShowCase/ThemeShowcase.tsx
+++ b/packages/frappe-ui-react/src/components/themeShowCase/ThemeShowcase.tsx
@@ -1326,7 +1326,7 @@ const ThemeShowcase: React.FC = () => {
                 {fontFamilies.map((font) => (
                   <div
                     key={font.name}
-                    className="p-4 bg-white"
+                    className="p-4 bg-surface-white"
                   >
                     <div className="flex items-baseline justify-between mb-2">
                       <span className="font-semibold text-gray-700">

--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -634,15 +634,15 @@ input {
 
     /* Override semantic colors for dark theme */
     --color-ink-white: var(--color-dark-gray-900);
-    --color-ink-gray-1: var(--color-dark-gray-100);
-    --color-ink-gray-2: var(--color-dark-gray-200);
-    --color-ink-gray-3: var(--color-dark-gray-300);
+    --color-ink-gray-1: var(--color-dark-gray-700);
+    --color-ink-gray-2: var(--color-dark-gray-500);
+    --color-ink-gray-3: var(--color-dark-gray-400);
     --color-ink-gray-4: var(--color-dark-gray-400);
-    --color-ink-gray-5: #999999;
-    --color-ink-gray-6: #c7c7c7;
-    --color-ink-gray-7: #ededed;
-    --color-ink-gray-8: #f3f3f3;
-    --color-ink-gray-9: #f8f8f8;
+    --color-ink-gray-5: var(--color-dark-gray-300);
+    --color-ink-gray-6: var(--color-dark-gray-250);
+    --color-ink-gray-7: var(--color-dark-gray-200);
+    --color-ink-gray-8: var(--color-dark-gray-100);
+    --color-ink-gray-9: var(--color-dark-gray-50);
     --color-ink-red-1: var(--color-dark-red-50);
     --color-ink-red-2: var(--color-dark-red-100);
     --color-ink-red-3: var(--color-dark-red-200);
@@ -663,13 +663,13 @@ input {
 
     /* Surface Colors for dark theme */
     --color-surface-white: var(--color-dark-gray-900);
-    --color-surface-gray-1: var(--color-dark-gray-800);
-    --color-surface-gray-2: var(--color-dark-gray-700);
-    --color-surface-gray-3: var(--color-dark-gray-650);
-    --color-surface-gray-4: var(--color-dark-gray-600);
-    --color-surface-gray-5: var(--color-dark-gray-500);
-    --color-surface-gray-6: var(--color-dark-gray-400);
-    --color-surface-gray-7: #f8f8f8;
+    --color-surface-gray-1: var(--color-dark-gray-700);
+    --color-surface-gray-2: var(--color-dark-gray-650);
+    --color-surface-gray-3: var(--color-dark-gray-600);
+    --color-surface-gray-4: var(--color-dark-gray-500);
+    --color-surface-gray-5: var(--color-dark-gray-200);
+    --color-surface-gray-6: var(--color-dark-gray-100);
+    --color-surface-gray-7: var(--color-dark-gray-50);
     --color-surface-red-1: var(--color-dark-red-900);
     --color-surface-red-2: var(--color-dark-red-800);
     --color-surface-red-3: var(--color-dark-red-700);
@@ -699,18 +699,18 @@ input {
     --color-surface-cyan-2: var(--color-dark-cyan-600);
     --color-surface-pink-1: var(--color-dark-pink-900);
     --color-surface-pink-2: var(--color-dark-pink-600);
-    --color-surface-menu-bar: var(--color-dark-gray-800);
-    --color-surface-cards: var(--color-dark-gray-700);
-    --color-surface-modal: var(--color-dark-gray-650);
-    --color-surface-selected: var(--color-dark-gray-600);
+    --color-surface-menu-bar: var(--color-dark-gray-900);
+    --color-surface-cards: var(--color-dark-gray-800);
+    --color-surface-modal: var(--color-dark-gray-700);
+    --color-surface-selected: var(--color-dark-gray-500);
 
     /* Outline Colors for dark theme */
-    --color-outline-white: var(--color-dark-gray-900);
-    --color-outline-gray-1: var(--color-dark-gray-650);
+    --color-outline-white: var(--color-dark-gray-800);
+    --color-outline-gray-1: var(--color-dark-gray-700);
     --color-outline-gray-2: var(--color-dark-gray-600);
     --color-outline-gray-3: var(--color-dark-gray-500);
-    --color-outline-gray-4: var(--color-dark-gray-400);
-    --color-outline-gray-5: var(--color-gray-400);
+    --color-outline-gray-4: var(--color-dark-gray-300);
+    --color-outline-gray-5: var(--color-gray-200);
     --color-outline-red-1: var(--color-dark-red-600);
     --color-outline-red-2: var(--color-dark-red-500);
     --color-outline-red-3: var(--color-dark-red-400);
@@ -720,7 +720,7 @@ input {
     --color-outline-amber-2: var(--color-dark-amber-600);
     --color-outline-blue-1: var(--color-dark-blue-700);
     --color-outline-orange-1: var(--color-dark-orange-700);
-    --color-outline-gray-modals: var(--color-dark-gray-650);
+    --color-outline-gray-modals: var(--color-dark-gray-600);
 
     /* Dark theme shadows - make them more prominent */
     --shadow-sm: 0px 1px 2px rgba(0, 0, 0, 0.3);

--- a/packages/frappe-ui-react/src/themeV3.css
+++ b/packages/frappe-ui-react/src/themeV3.css
@@ -635,15 +635,15 @@ input {
 
     /* Override semantic colors for dark theme */
     --color-ink-white: var(--color-dark-gray-900);
-    --color-ink-gray-1: var(--color-dark-gray-100);
-    --color-ink-gray-2: var(--color-dark-gray-200);
-    --color-ink-gray-3: var(--color-dark-gray-300);
+    --color-ink-gray-1: var(--color-dark-gray-700);
+    --color-ink-gray-2: var(--color-dark-gray-500);
+    --color-ink-gray-3: var(--color-dark-gray-400);
     --color-ink-gray-4: var(--color-dark-gray-400);
-    --color-ink-gray-5: #999999;
-    --color-ink-gray-6: #c7c7c7;
-    --color-ink-gray-7: #ededed;
-    --color-ink-gray-8: #f3f3f3;
-    --color-ink-gray-9: #f8f8f8;
+    --color-ink-gray-5: var(--color-dark-gray-300);
+    --color-ink-gray-6: var(--color-dark-gray-250);
+    --color-ink-gray-7: var(--color-dark-gray-200);
+    --color-ink-gray-8: var(--color-dark-gray-100);
+    --color-ink-gray-9: var(--color-dark-gray-50);
     --color-ink-red-1: var(--color-dark-red-50);
     --color-ink-red-2: var(--color-dark-red-100);
     --color-ink-red-3: var(--color-dark-red-200);
@@ -664,13 +664,13 @@ input {
 
     /* Surface Colors for dark theme */
     --color-surface-white: var(--color-dark-gray-900);
-    --color-surface-gray-1: var(--color-dark-gray-800);
-    --color-surface-gray-2: var(--color-dark-gray-700);
-    --color-surface-gray-3: var(--color-dark-gray-650);
-    --color-surface-gray-4: var(--color-dark-gray-600);
-    --color-surface-gray-5: var(--color-dark-gray-500);
-    --color-surface-gray-6: var(--color-dark-gray-400);
-    --color-surface-gray-7: #f8f8f8;
+    --color-surface-gray-1: var(--color-dark-gray-700);
+    --color-surface-gray-2: var(--color-dark-gray-650);
+    --color-surface-gray-3: var(--color-dark-gray-600);
+    --color-surface-gray-4: var(--color-dark-gray-500);
+    --color-surface-gray-5: var(--color-dark-gray-200);
+    --color-surface-gray-6: var(--color-dark-gray-100);
+    --color-surface-gray-7: var(--color-dark-gray-50);
     --color-surface-red-1: var(--color-dark-red-900);
     --color-surface-red-2: var(--color-dark-red-800);
     --color-surface-red-3: var(--color-dark-red-700);
@@ -700,18 +700,18 @@ input {
     --color-surface-cyan-2: var(--color-dark-cyan-600);
     --color-surface-pink-1: var(--color-dark-pink-900);
     --color-surface-pink-2: var(--color-dark-pink-600);
-    --color-surface-menu-bar: var(--color-dark-gray-800);
-    --color-surface-cards: var(--color-dark-gray-700);
-    --color-surface-modal: var(--color-dark-gray-650);
-    --color-surface-selected: var(--color-dark-gray-600);
+    --color-surface-menu-bar: var(--color-dark-gray-900);
+    --color-surface-cards: var(--color-dark-gray-800);
+    --color-surface-modal: var(--color-dark-gray-700);
+    --color-surface-selected: var(--color-dark-gray-500);
 
     /* Outline Colors for dark theme */
-    --color-outline-white: var(--color-dark-gray-900);
-    --color-outline-gray-1: var(--color-dark-gray-650);
+    --color-outline-white: var(--color-dark-gray-800);
+    --color-outline-gray-1: var(--color-dark-gray-700);
     --color-outline-gray-2: var(--color-dark-gray-600);
     --color-outline-gray-3: var(--color-dark-gray-500);
-    --color-outline-gray-4: var(--color-dark-gray-400);
-    --color-outline-gray-5: var(--color-gray-400);
+    --color-outline-gray-4: var(--color-dark-gray-300);
+    --color-outline-gray-5: var(--color-gray-200);
     --color-outline-red-1: var(--color-dark-red-600);
     --color-outline-red-2: var(--color-dark-red-500);
     --color-outline-red-3: var(--color-dark-red-400);
@@ -721,7 +721,7 @@ input {
     --color-outline-amber-2: var(--color-dark-amber-600);
     --color-outline-blue-1: var(--color-dark-blue-700);
     --color-outline-orange-1: var(--color-dark-orange-700);
-    --color-outline-gray-modals: var(--color-dark-gray-650);
+    --color-outline-gray-modals: var(--color-dark-gray-600);
 
     /* Dark theme shadows - make them more prominent */
     --shadow-sm: 0px 1px 2px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
- Fixes incorrect colors used in dark mode
- Fixes components and theme showcase with incorrect dark mode colors
<div style="display:flex;"> 
<img width="300"  src="https://github.com/user-attachments/assets/83af8f03-39b1-462f-99c4-96a8a0716a27" />
<img width="300"src="https://github.com/user-attachments/assets/94eab28c-b4de-490a-bec2-5e58b35c2f3d" />
</div>

- Fixes prefix alignment issue with AutoComplete component
<div style="display:flex;"> 
<img width="300"   src="https://github.com/user-attachments/assets/60868687-88d2-4666-9a48-a793b806fbaa" />
<img width="300" src="https://github.com/user-attachments/assets/01b4ba77-849a-40d7-ac48-43b0b3a94319" />
</div>

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

Before:

https://github.com/user-attachments/assets/8ebcb22d-1c14-46ca-8f2a-a35cc63a3661


After:

https://github.com/user-attachments/assets/81c9dc90-55cc-4422-aaa4-f0ae943992c9

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
