### PR TITLE
Add Prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
## Description

This PR adds a Prettier configuration to restore the trailing comma behavior used in our previous Prettier setup. Prettier 3.7.4 (introduced in https://github.com/rtCamp/frappe-ui-react/pull/116) changed the default `trailingComma` option to `"all"`, which also adds trailing commas to function parameters. By explicitly setting `trailingComma` to `"es5"`, this PR aligns the formatting with the Prettier 2 defaults and prevents trailing commas from being added to function parameters while preserving trailing commas for objects and arrays.


<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #
