### PR TITLE
Fix: Add an Quill alias in Storybook configuration

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -32,6 +32,7 @@ const config: StorybookConfig = {
             __dirname,
             "../packages/frappe-ui-react/src"
           ),
+          Quill: require.resolve("quill"),
         },
       },
     };


### PR DESCRIPTION
## Description

The build error failed to resolve module specifier "Quill" because the `quill-resize-module` library contains this specific line in its source code:

File: `node_modules/quill-resize-module/dist/resize.js`

```js
require("Quill") // or import ... from "Quill"
```

It is trying to import the library using the capitalized name "Quill". However, the strict package name in `node_modules` is "quill" (lowercase). On case-sensitive file systems (like Linux, which GitHub Actions uses) or strict bundlers (like Vite), "Quill" is treated as a different, non-existent package.

## Relevant Technical Choices

Added an alias in the Storybook configuration
```
alias: {
  // ...
  Quill: require.resolve("quill"), 
}
```

This bridges the gap between the library's expectation and the actual package name, allowing the build to succeed.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Additional Information:

<!-- Any other information. -->

## Screenshot/Screencast

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [x] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Related #128 
