### PR TITLE
Feature: Add date picker range support to filters

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
@@ -116,6 +116,11 @@ const sampleFields: FilterField[] = [
     label: "Estimate (hours)",
     type: "number",
   },
+  {
+    name: "date_range",
+    label: "Date Range",
+    type: "daterange",
+  },
 ];
 
 // Controlled component wrapper

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -33,7 +33,7 @@ export const Filter: React.FC<FilterProps> = ({
       field: firstField?.name || "",
       operator: "",
       value: null,
-      fieldCategory: firstField?.fieldCategory || "",
+      fieldCategory: firstField?.fieldCategory,
     };
   }, [fields]);
 
@@ -114,7 +114,7 @@ export const Filter: React.FC<FilterProps> = ({
             <Popover.Popup
               className={cn(
                 "rounded-lg border shadow-xl bg-surface-modal border-outline-gray-1",
-                "p-3 min-w-100 max-w-150 a nimate-fade-in z-100"
+                "p-3 min-w-100 max-w-150 animate-fade-in z-100"
               )}
             >
               <div className="space-y-1">

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -65,9 +65,13 @@ export const Filter: React.FC<FilterProps> = ({
   );
 
   // Clear all filters
-  const handleClearAll = useCallback(() => {
-    onChange?.([]);
-  }, [onChange]);
+  const handleClearAll = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      onChange?.([]);
+    },
+    [onChange]
+  );
 
   // Handle popover open - add initial filter if empty
   const handleOpenChange = useCallback(

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -33,6 +33,7 @@ export const Filter: React.FC<FilterProps> = ({
       field: firstField?.name || "",
       operator: "",
       value: null,
+      fieldCategory: firstField?.fieldCategory || "",
     };
   }, [fields]);
 
@@ -112,7 +113,7 @@ export const Filter: React.FC<FilterProps> = ({
           <Popover.Positioner sideOffset={4} align={align}>
             <Popover.Popup
               className={cn(
-                "bg-surface-modal border border-outline-gray-1 rounded-lg shadow-xl",
+                "rounded-lg border shadow-xl bg-surface-modal border-outline-gray-1",
                 "p-3 min-w-100 max-w-150 a nimate-fade-in z-100"
               )}
             >
@@ -138,7 +139,7 @@ export const Filter: React.FC<FilterProps> = ({
                     "hover:text-ink-gray-7 mt-2 py-1 transition-colors"
                   )}
                 >
-                  <Plus className="h-4 w-4" />
+                  <Plus className="w-4 h-4" />
                   Add filter
                 </button>
               )}

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -133,7 +133,7 @@ export const Filter: React.FC<FilterProps> = ({
             <Popover.Popup
               className={cn(
                 "rounded-lg border shadow-xl bg-surface-modal border-outline-gray-1",
-                "p-3 min-w-100 max-w-150 animate-fade-in z-100"
+                "p-1 min-w-100 max-w-150 animate-fade-in z-100"
               )}
             >
               <div className="space-y-1">
@@ -154,7 +154,7 @@ export const Filter: React.FC<FilterProps> = ({
                 <button
                   onClick={handleAddFilter}
                   className={cn(
-                    "flex items-center gap-1.5 text-sm text-ink-gray-5",
+                    "flex items-center gap-1.5 text-sm text-ink-gray-5 px-2 py-1.5",
                     "hover:text-ink-gray-7 mt-2 py-1 transition-colors"
                   )}
                 >

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -85,27 +85,42 @@ export const Filter: React.FC<FilterProps> = ({
       <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
         <Popover.Trigger
           render={
-            <Button
-              size="sm"
-              iconLeft={() => (
-                <ListFilter size={16} className="text-ink-gray-7" />
+            <span>
+              <Button
+                size="sm"
+                iconLeft={() => (
+                  <ListFilter size={16} className="text-ink-gray-7" />
+                )}
+                iconRight={
+                  !hasFilters
+                    ? () => (
+                        <ChevronDown size={16} className="text-ink-gray-5" />
+                      )
+                    : undefined
+                }
+                className={cn("gap-2", {
+                  "rounded-r-none border-r-0": hasFilters,
+                })}
+              >
+                Filter
+                {showCount && hasFilters && (
+                  <span className="ml-2 px-1.5 py-0.5 text-xs bg-white rounded-sm shadow-sm">
+                    {filterCount}
+                  </span>
+                )}
+              </Button>
+
+              {/* Clear all button (shown when filters exist) */}
+              {hasFilters && (
+                <Button
+                  icon="x"
+                  size="sm"
+                  onClick={handleClearAll}
+                  className="rounded-l-none border-l border-l-outline-gray-2"
+                  aria-label="Clear all filters"
+                />
               )}
-              iconRight={
-                !hasFilters
-                  ? () => <ChevronDown size={16} className="text-ink-gray-5" />
-                  : undefined
-              }
-              className={cn("gap-2", {
-                "rounded-r-none border-r-0": hasFilters,
-              })}
-            >
-              Filter
-              {showCount && hasFilters && (
-                <span className="ml-2 px-1.5 py-0.5 text-xs bg-white rounded-sm shadow-sm">
-                  {filterCount}
-                </span>
-              )}
-            </Button>
+            </span>
           }
         />
 
@@ -147,17 +162,6 @@ export const Filter: React.FC<FilterProps> = ({
           </Popover.Positioner>
         </Popover.Portal>
       </Popover.Root>
-
-      {/* Clear all button (shown when filters exist) */}
-      {hasFilters && (
-        <Button
-          icon="x"
-          size="sm"
-          onClick={handleClearAll}
-          className="rounded-l-none border-l border-l-outline-gray-2"
-          aria-label="Clear all filters"
-        />
-      )}
     </div>
   );
 };

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 import { ChevronDown } from "lucide-react";
 import { Button } from "../button";
-import { DatePicker } from "../datePicker";
-import { DateRangePicker } from "../datePicker";
+import { DatePicker, DateRangePicker } from "../datePicker";
 import { FilterSelect } from "./filterSelect";
 import { cn } from "../../utils";
 import type {
@@ -19,10 +18,10 @@ const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
     { label: "Not Like", value: "not like" },
   ],
   number: [
-    { label: "<", value: "<" },
-    { label: ">", value: ">" },
-    { label: "<=", value: "<=" },
-    { label: ">=", value: ">=" },
+    { label: "Greater Than", value: ">" },
+    { label: "Less Than", value: "<" },
+    { label: "Less Than or Equal To", value: "<=" },
+    { label: "Greater Than or Equal To", value: ">=" },
     { label: "Equals", value: "=" },
     { label: "Not Equals", value: "!=" },
   ],
@@ -174,9 +173,10 @@ export const FilterRow: React.FC<FilterRowProps> = ({
             <DatePicker
               value={typeof filter.value === "string" ? filter.value : ""}
               onChange={(v) =>
-                handleValueChange(typeof v === "string" ? v : null)
+                handleValueChange(
+                  v === "" ? null : typeof v === "string" ? v : null
+                )
               }
-              placeholder="Select date"
             >
               {({ displayValue }) => (
                 <DatePickerTrigger
@@ -190,8 +190,13 @@ export const FilterRow: React.FC<FilterRowProps> = ({
           return (
             <DateRangePicker
               value={Array.isArray(filter.value) ? filter.value : []}
-              onChange={(v) => handleValueChange(v)}
-              placeholder="Select date range"
+              onChange={(v) => {
+                if (Array.isArray(v) && v.length === 2 && !v[0] && !v[1]) {
+                  handleValueChange(null);
+                } else {
+                  handleValueChange(v);
+                }
+              }}
             >
               {({ displayValue }) => (
                 <DatePickerTrigger

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -141,7 +141,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
   return (
     <div className="flex gap-2 items-center py-1">
       {/* Where / And label */}
-      <span className="w-12 text-sm text-ink-gray-5 shrink-0">
+      <span className="w-12 text-sm text-ink-gray-7 shrink-0 px-2 py-1.5">
         {isFirst ? "Where" : "And"}
       </span>
 
@@ -245,7 +245,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
         variant="ghost"
         size="sm"
         onClick={onRemove}
-        className="text-ink-gray-4 hover:text-ink-gray-6 shrink-0"
+        className="text-ink-gray-7 hover:text-ink-gray-6 shrink-0"
         aria-label="Remove filter"
       />
     </div>

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from "react";
+import { ChevronDown } from "lucide-react";
 import { Button } from "../button";
+import { DatePicker } from "../datePicker";
+import { DateRangePicker } from "../datePicker";
 import { FilterSelect } from "./filterSelect";
 import { cn } from "../../utils";
 import type {
@@ -10,22 +13,18 @@ import type {
 
 const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
   string: [
-    { label: "is", value: "is" },
-    { label: "is not", value: "is_not" },
-    { label: "contains", value: "contains" },
-    { label: "does not contain", value: "not_contains" },
-    { label: "starts with", value: "starts_with" },
-    { label: "ends with", value: "ends_with" },
-    { label: "is empty", value: "is_empty", hideValue: true },
-    { label: "is not empty", value: "is_not_empty", hideValue: true },
+    { label: "Equals", value: "=" },
+    { label: "Not Equals", value: "!=" },
+    { label: "Like", value: "like" },
+    { label: "Not Like", value: "not like" },
   ],
   number: [
-    { label: "=", value: "is" },
-    { label: "≠", value: "is_not" },
-    { label: ">", value: "greater_than" },
-    { label: "<", value: "less_than" },
-    { label: "is empty", value: "is_empty", hideValue: true },
-    { label: "is not empty", value: "is_not_empty", hideValue: true },
+    { label: "<", value: "<" },
+    { label: ">", value: ">" },
+    { label: "<=", value: "<=" },
+    { label: ">=", value: ">=" },
+    { label: "Equals", value: "=" },
+    { label: "Not Equals", value: "!=" },
   ],
   select: [
     { label: "is", value: "is" },
@@ -40,6 +39,7 @@ const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
     { label: "is empty", value: "is_empty", hideValue: true },
     { label: "is not empty", value: "is_not_empty", hideValue: true },
   ],
+  daterange: [{ label: "Between", value: "between" }],
   default: [
     { label: "is", value: "is" },
     { label: "is not", value: "is_not" },
@@ -116,6 +116,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
       field: value,
       operator: firstOperator,
       value: null,
+      fieldCategory: newField?.fieldCategory,
     });
   };
 
@@ -131,7 +132,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
     });
   };
 
-  const handleValueChange = (value: string | null) => {
+  const handleValueChange = (value: string | string[] | null) => {
     onChange({
       ...filter,
       value,
@@ -139,9 +140,9 @@ export const FilterRow: React.FC<FilterRowProps> = ({
   };
 
   return (
-    <div className="flex items-center gap-2 py-1">
+    <div className="flex gap-2 items-center py-1">
       {/* Where / And label */}
-      <span className="text-ink-gray-5 text-sm w-12 shrink-0">
+      <span className="w-12 text-sm text-ink-gray-5 shrink-0">
         {isFirst ? "Where" : "And"}
       </span>
 
@@ -164,34 +165,74 @@ export const FilterRow: React.FC<FilterRowProps> = ({
         disabled={!filter.field}
       />
 
-      {/* Value selector (only if not hidden) */}
-      {!hideValue &&
-        (valueOptions.length > 0 ? (
-          <FilterSelect
-            value={typeof filter.value === "string" ? filter.value : null}
-            options={valueOptions}
-            onChange={handleValueChange}
-            placeholder="Value"
-            minWidth={140}
-            disabled={!filter.operator}
-          />
-        ) : (
-          <input
-            type={selectedField?.type === "number" ? "number" : "text"}
-            value={filter.value?.toString() ?? ""}
-            onChange={(e) => handleValueChange(e.target.value || null)}
-            placeholder="Value"
-            disabled={!filter.operator}
-            className={cn(
-              "min-w-35 bg-surface-gray-2 border-none rounded",
-              "px-2 py-1 min-h-7 text-base",
-              "placeholder-ink-gray-4 text-ink-gray-8",
-              "outline-none focus:ring-2 focus:ring-outline-gray-3",
-              "transition-colors",
-              "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
-            )}
-          />
-        ))}
+      {/* Value selector */}
+      {(() => {
+        if (hideValue) {
+          return null;
+        } else if (selectedField?.type === "date") {
+          return (
+            <DatePicker
+              value={typeof filter.value === "string" ? filter.value : ""}
+              onChange={(v) =>
+                handleValueChange(typeof v === "string" ? v : null)
+              }
+              placeholder="Select date"
+            >
+              {({ displayValue }) => (
+                <DatePickerTrigger
+                  displayValue={displayValue}
+                  disabled={!filter.operator}
+                />
+              )}
+            </DatePicker>
+          );
+        } else if (selectedField?.type === "daterange") {
+          return (
+            <DateRangePicker
+              value={Array.isArray(filter.value) ? filter.value : []}
+              onChange={(v) => handleValueChange(v)}
+              placeholder="Select date range"
+            >
+              {({ displayValue }) => (
+                <DatePickerTrigger
+                  displayValue={displayValue}
+                  disabled={!filter.operator}
+                  minWidth={180}
+                />
+              )}
+            </DateRangePicker>
+          );
+        } else if (valueOptions.length > 0) {
+          return (
+            <FilterSelect
+              value={typeof filter.value === "string" ? filter.value : null}
+              options={valueOptions}
+              onChange={handleValueChange}
+              placeholder="Value"
+              minWidth={140}
+              disabled={!filter.operator}
+            />
+          );
+        } else {
+          return (
+            <input
+              type={selectedField?.type === "number" ? "number" : "text"}
+              value={filter.value?.toString() ?? ""}
+              onChange={(e) => handleValueChange(e.target.value || null)}
+              placeholder="Value"
+              disabled={!filter.operator}
+              className={cn(
+                "rounded border-none min-w-35 bg-surface-gray-2",
+                "px-2 py-1 text-base min-h-7",
+                "placeholder-ink-gray-4 text-ink-gray-8",
+                "outline-none focus:ring-2 focus:ring-outline-gray-3",
+                "transition-colors",
+                "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
+              )}
+            />
+          );
+        }
+      })()}
 
       {/* Remove button */}
       <Button
@@ -205,5 +246,37 @@ export const FilterRow: React.FC<FilterRowProps> = ({
     </div>
   );
 };
+
+interface DatePickerTriggerProps {
+  displayValue: string;
+  disabled?: boolean;
+  minWidth?: number;
+}
+
+const DatePickerTrigger: React.FC<DatePickerTriggerProps> = ({
+  displayValue,
+  disabled,
+  minWidth = 140,
+}) => (
+  <div className="relative" style={{ minWidth }}>
+    <button
+      type="button"
+      disabled={disabled}
+      className={cn(
+        "w-full rounded border-none bg-surface-gray-2",
+        "py-1 pr-6 pl-2 text-base text-left min-h-7",
+        "outline-none focus:ring-2 focus:ring-outline-gray-3",
+        "transition-colors cursor-pointer",
+        "truncate disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
+        displayValue ? "text-ink-gray-8" : "text-ink-gray-4"
+      )}
+    >
+      {displayValue || "Value"}
+    </button>
+    <span className="absolute inset-y-0 right-0 flex items-center pr-1.5 text-ink-gray-4 pointer-events-none">
+      <ChevronDown className="w-4 h-4" />
+    </span>
+  </div>
+);
 
 export default FilterRow;

--- a/packages/frappe-ui-react/src/components/filter/types.ts
+++ b/packages/frappe-ui-react/src/components/filter/types.ts
@@ -40,12 +40,14 @@ export interface FilterOperatorOption {
 
 /** Field definition for what can be filtered */
 export interface FilterField {
+  /** The category of the field being filtered */
+  fieldCategory?: string;
   /** Unique identifier for the field */
   name: string;
   /** Display label */
   label: string;
   /** Field type determines available operators and value input */
-  type?: "string" | "number" | "date" | "select" | "multiselect";
+  type?: "string" | "number" | "date" | "daterange" | "select" | "multiselect";
   /** Available operators for this field (defaults based on type) */
   operators?: FilterOperatorOption[];
   /** Options for select/multiselect type fields */
@@ -60,6 +62,8 @@ export interface FilterCondition {
   id: string;
   /** The field being filtered */
   field: string;
+  /** The category of the field being filtered */
+  fieldCategory?: string;
   /** The operator being applied */
   operator: string;
   /** The value(s) to filter by */


### PR DESCRIPTION
## Description
- Adds date picker range and date picker support to filters.
- Updates filters and introduces fieldCategory property which will be useful for filtering. Since the frappe ecosystem supports filter in the format:
```
[["Project","expected_start_date","Between",["2026-03-16","2026-03-25"]]]
i.e.
[["fieldCategory","field","operator","value"]]
```

## Screenshot/Screencast

<img width="730" height="428" alt="image" src="https://github.com/user-attachments/assets/f349bb28-7e51-48b7-85b7-66edc4d53d6b" />

<img width="709" height="427" alt="image" src="https://github.com/user-attachments/assets/b52777e6-c446-4b53-83fb-1a5781c6de66" />

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
