### PR TITLE
fix: remove unnecessary class from TabPanel

### DIFF
--- a/packages/frappe-ui-react/src/components/tabs/tabPanel.tsx
+++ b/packages/frappe-ui-react/src/components/tabs/tabPanel.tsx
@@ -14,7 +14,7 @@ export const TabPanel = ({ tabs, className }: TabPanelProps) => {
         <BaseUITabs.Panel
           key={tab.label}
           value={tab.label}
-          className="flex flex-1 flex-col overflow-y-auto focus:outline-none"
+          className="flex flex-1 flex-col focus:outline-none"
         >
           {tab.content}
         </BaseUITabs.Panel>


### PR DESCRIPTION
## Description
- Removed the overflow-y-auto class from the tab panel because we have a div wrapper on top of it which also controls to overflow. Having double overflows prevents us to achive full width effect via negative margin. Like for this component:

Enabled overflow:
<img width="1638" height="577" alt="image" src="https://github.com/user-attachments/assets/a41cfba8-f664-4c7c-a0ab-2ac741f19fef" />

Disabled overlfow:
<img width="1629" height="618" alt="image" src="https://github.com/user-attachments/assets/5c278c2d-52b1-4e3a-a199-52813a93c2bf" />

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
