### PR TITLE
Fix: SVG Update

### DIFF
--- a/packages/frappe-ui-react/src/icons/solid/priority-high.svg
+++ b/packages/frappe-ui-react/src/icons/solid/priority-high.svg
@@ -1,12 +1,12 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_18125_4162)">
-<rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="#171717"/>
-<rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="#171717"/>
-<rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="#171717"/>
-</g>
-<defs>
-<clipPath id="clip0_18125_4162">
-<rect width="9.5" height="12" fill="white" transform="translate(3.25 2)"/>
-</clipPath>
-</defs>
+  <g clip-path="url(#clip0_18125_4162)">
+    <rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="currentColor" />
+    <rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="currentColor" />
+    <rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="currentColor" />
+  </g>
+  <defs>
+    <clipPath id="clip0_18125_4162">
+      <rect width="9.5" height="12" fill="white" transform="translate(3.25 2)" />
+    </clipPath>
+  </defs>
 </svg>

--- a/packages/frappe-ui-react/src/icons/solid/priority-low.svg
+++ b/packages/frappe-ui-react/src/icons/solid/priority-low.svg
@@ -1,12 +1,12 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_18125_4145)">
-<rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="#E2E2E2"/>
-<rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="#E2E2E2"/>
-<rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="#171717"/>
-</g>
-<defs>
-<clipPath id="clip0_18125_4145">
-<rect width="9.5" height="12" fill="white" transform="translate(3.25 2)"/>
-</clipPath>
-</defs>
+  <g clip-path="url(#clip0_18125_4145)">
+    <rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="currentColor" fill-opacity="0.4" />
+    <rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="currentColor" fill-opacity="0.4" />
+    <rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="currentColor" />
+  </g>
+  <defs>
+    <clipPath id="clip0_18125_4145">
+      <rect width="9.5" height="12" fill="white" transform="translate(3.25 2)" />
+    </clipPath>
+  </defs>
 </svg>

--- a/packages/frappe-ui-react/src/icons/solid/priority-medium.svg
+++ b/packages/frappe-ui-react/src/icons/solid/priority-medium.svg
@@ -1,12 +1,12 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_18125_4163)">
-<rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="#E2E2E2"/>
-<rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="#171717"/>
-<rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="#171717"/>
-</g>
-<defs>
-<clipPath id="clip0_18125_4163">
-<rect width="9.5" height="12" fill="white" transform="translate(3.25 2)"/>
-</clipPath>
-</defs>
+  <g clip-path="url(#clip0_18125_4163)">
+    <rect x="11.25" y="2" width="1.5" height="12" rx="0.5" fill="currentColor" fill-opacity="0.4" />
+    <rect x="7.25" y="6" width="1.5" height="8" rx="0.5" fill="currentColor" />
+    <rect x="3.25" y="10" width="1.5" height="4" rx="0.5" fill="currentColor" />
+  </g>
+  <defs>
+    <clipPath id="clip0_18125_4163">
+      <rect width="9.5" height="12" fill="white" transform="translate(3.25 2)" />
+    </clipPath>
+  </defs>
 </svg>


### PR DESCRIPTION
## Description
 - Update svg code to use current color instead of hardcoded color values, this enables us to pass color values via setting text color without explicitly setting fill color or path color.

## Screenshot/Screencast
<img width="2178" height="1382" alt="image" src="https://github.com/user-attachments/assets/86b9f7ee-8f2a-4e82-88d1-8b29040d189f" />

<img width="512" height="176" alt="image" src="https://github.com/user-attachments/assets/6fe90f60-933e-4a9e-abe0-2171c980f342" />

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).