### PR TITLE
Fix Autocomplete keyboard navigation

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
@@ -217,14 +217,13 @@ export const MultipleSelectionFooter: Story = {
 export const ControlledSearchLoading: Story = {
   args: {
     options: directoryOptions,
-    value: null,
-    placeholder: "Select a person",
+    value: [],
+    multiple: true,
+    keepSelectedVisible: true,
+    placeholder: "Select people",
   },
   render: function Render(args) {
-    const [value, setValue] = React.useState<string | null>(null);
-    const [selectedOption, setSelectedOption] = React.useState<
-      (typeof directoryOptions)[number] | null
-    >(null);
+    const [value, setValue] = React.useState<string[]>([]);
     const [searchValue, setSearchValue] = React.useState("");
     const [loading, setLoading] = React.useState(false);
     const [options, setOptions] = React.useState(directoryOptions);
@@ -259,16 +258,15 @@ export const ControlledSearchLoading: Story = {
       <div className="w-112.5">
         <Autocomplete
           {...args}
+          multiple
+          keepSelectedVisible
+          value={value}
           options={options}
-          value={selectedOption ?? value}
           searchValue={searchValue}
           loading={loading}
           onSearchChange={setSearchValue}
-          onChange={(nextValue, nextOption) => {
-            setValue(nextValue as string | null);
-            setSelectedOption(
-              (nextOption as (typeof directoryOptions)[number] | null) ?? null
-            );
+          onChange={(_value) => {
+            setValue(_value as string[]);
           }}
         />
       </div>
@@ -280,13 +278,12 @@ export const ControlledSearchLoading: Story = {
     const trigger = canvas.getByRole("combobox", { name: /toggle options/i });
 
     await userEvent.click(trigger);
+    await userEvent.click(await page.findByText("John Doe"));
+    await userEvent.click(await page.findByText("Jane Doe"));
 
     const search = await page.findByPlaceholderText("Search");
+    await userEvent.clear(search);
     await userEvent.type(search, "smith");
-
-    await waitFor(() => {
-      expect(search).toHaveValue("smith");
-    });
 
     await waitFor(() => {
       expect(page.getByTestId("loading-indicator")).toBeInTheDocument();
@@ -296,30 +293,18 @@ export const ControlledSearchLoading: Story = {
       expect(page.getByText("John Smith")).toBeInTheDocument();
     });
 
-    await userEvent.click(page.getByText("John Smith"));
+    expect(page.getByText("John Doe")).toBeInTheDocument();
+    expect(page.getByText("Jane Doe")).toBeInTheDocument();
+    expect(page.queryByText("Bob Johnson")).not.toBeInTheDocument();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, "zzz");
 
     await waitFor(() => {
-      expect(trigger).toHaveTextContent("John Smith");
+      expect(page.queryByText("John Smith")).not.toBeInTheDocument();
     });
 
-    await userEvent.click(trigger);
-
-    const reopenedSearch = await page.findByPlaceholderText("Search");
-    await userEvent.clear(reopenedSearch);
-    await userEvent.type(reopenedSearch, "zzz");
-
-    await waitFor(() => {
-      expect(reopenedSearch).toHaveValue("zzz");
-    });
-
-    await waitFor(() => {
-      expect(page.getByText('No results found for "zzz"')).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(trigger).toHaveTextContent("John Smith");
-    });
-
-    expect(page.queryByText("John Doe")).not.toBeInTheDocument();
+    expect(page.getByText("John Doe")).toBeInTheDocument();
+    expect(page.getByText("Jane Doe")).toBeInTheDocument();
   },
 };

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.stories.tsx
@@ -69,6 +69,11 @@ const meta: Meta<typeof Autocomplete> = {
       control: "number",
       description: "Maximum number of options to display.",
     },
+    keepSelectedVisible: {
+      control: "boolean",
+      description:
+        "Keep selected options visible in the list even if they don't match the search query.",
+    },
     searchValue: {
       control: "text",
       description: "Controlled search text shown in the popup input.",
@@ -299,10 +304,7 @@ export const MultipleOptionsWithoutSearch: Story = {
 
 export const ControlledSearchLoading: Story = {
   render: (args) => {
-    const [value, setValue] = useState<string | null>(null);
-    const [selectedOption, setSelectedOption] = useState<
-      (typeof options)[number] | null
-    >(null);
+    const [value, setValue] = useState<string[]>([]);
     const [searchValue, setSearchValue] = useState("");
     const [loading, setLoading] = useState(false);
     const [filteredOptions, setFilteredOptions] = useState(options);
@@ -337,16 +339,15 @@ export const ControlledSearchLoading: Story = {
       <div style={{ width: "450px" }}>
         <Autocomplete
           {...args}
-          value={selectedOption ?? value}
+          multiple
+          value={value}
           options={filteredOptions}
           searchValue={searchValue}
           loading={loading}
+          keepSelectedVisible
           onSearchChange={setSearchValue}
-          onChange={(_value, nextOption) => {
-            setValue(_value as string | null);
-            setSelectedOption(
-              (nextOption as (typeof options)[number] | null) ?? null
-            );
+          onChange={(_value) => {
+            setValue(_value as string[]);
           }}
         />
       </div>

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -119,6 +119,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
 
     if (!keepSelectedVisible) return filtered;
 
+    // Ensure selected options are visible even if they don't match the query.
     const selectionArray = Array.isArray(selectedOptionCache)
       ? selectedOptionCache
       : selectedOptionCache
@@ -127,7 +128,6 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
 
     if (!selectionArray.length) return filtered;
 
-    // Ensure selected options are visible even if they don't match the query.
     const withoutSelected = filtered
       .map((group) => ({
         ...group,

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -55,6 +55,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   itemPrefix,
   itemSuffix,
   maxOptions = 50,
+  keepSelectedVisible = false,
   searchValue,
   open,
   compareFn = defaultCompareFn,
@@ -113,14 +114,43 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   );
 
   const visibleGroups = useMemo(() => {
-    if (isSearchControlled) {
-      return loading
-        ? filterGroups(displayedGroups, query, maxOptions)
-        : filterGroups(displayedGroups, "", maxOptions);
-    }
+    const effectiveQuery = isSearchControlled && !loading ? "" : query;
+    const filtered = filterGroups(displayedGroups, effectiveQuery, maxOptions);
 
-    return filterGroups(displayedGroups, query, maxOptions);
-  }, [displayedGroups, isSearchControlled, loading, maxOptions, query]);
+    if (!keepSelectedVisible) return filtered;
+
+    const selectionArray = Array.isArray(selectedOptionCache)
+      ? selectedOptionCache
+      : selectedOptionCache
+        ? [selectedOptionCache]
+        : [];
+
+    if (!selectionArray.length) return filtered;
+
+    // Ensure selected options are visible even if they don't match the query.
+    const withoutSelected = filtered
+      .map((group) => ({
+        ...group,
+        items: group.items.filter(
+          (item) => !selectionArray.some((sel) => compareFn(item, sel))
+        ),
+      }))
+      .filter((group) => group.items.length > 0);
+
+    return [
+      { group: "", hideLabel: true, items: selectionArray },
+      ...withoutSelected,
+    ];
+  }, [
+    compareFn,
+    displayedGroups,
+    isSearchControlled,
+    keepSelectedVisible,
+    loading,
+    maxOptions,
+    query,
+    selectedOptionCache,
+  ]);
 
   const renderedOptions = useMemo(
     () => flattenGroups(visibleGroups),
@@ -321,6 +351,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
         multiple={multiple}
         open={popupOpen}
         autoHighlight
+        filter={null}
         highlightItemOnHover
         itemToStringLabel={(item) => item.label}
         isItemEqualToValue={isSameOption}

--- a/packages/frappe-ui-react/src/components/autoComplete/types.ts
+++ b/packages/frappe-ui-react/src/components/autoComplete/types.ts
@@ -63,6 +63,7 @@ export interface AutocompleteProps {
   hideSearch?: boolean;
   showFooter?: boolean;
   maxOptions?: number;
+  keepSelectedVisible?: boolean;
   searchValue?: string;
   open?: boolean;
   compareFn?: (


### PR DESCRIPTION


## Description

<!-- What do we want to achieve with this PR? -->
This pull request adds an explicit prop (`keepSelectedVisible`) to enable keeping selected options visible in the dropdown list, even if they don't match the current search query. It also fixes keyboard navigation when searching with selected items, which was not working correctly.

## Relevant Technical Choices

<!-- Please describe your changes. -->

- Updated the code to pass `filter={null}` to the base UI component, ensuring that only the custom filtering logic is used. This was the root cause of the keyboard navigation issue.


---

## Screenshot


https://github.com/user-attachments/assets/e63d9f3b-6e47-4a29-bd69-339c55af51f2



## Checklist

<!-- Check these after PR creation -->

- [ ] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
