### PR TITLE
update onFailure prop type and error handling in FileUploader

### DIFF
--- a/packages/frappe-ui-react/src/components/fileUploader/fileuploader.tsx
+++ b/packages/frappe-ui-react/src/components/fileUploader/fileuploader.tsx
@@ -23,7 +23,7 @@ export interface FileUploaderProps {
     openFileSelector: () => void;
   }) => React.ReactNode;
   onSuccess?: (data: UploadedFile) => void;
-  onFailure?: (error: string) => void;
+  onFailure?: (error: unknown, errorMessage?: string) => void;
 }
 
 const FileUploader: React.FC<FileUploaderProps> = ({
@@ -146,7 +146,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({
           }
         }
         setError(errorMessage);
-        onFailure?.(errorMessage);
+        onFailure?.(err, errorMessage);
       });
   };
 

--- a/packages/frappe-ui-react/src/components/fileUploader/fileuploader.tsx
+++ b/packages/frappe-ui-react/src/components/fileUploader/fileuploader.tsx
@@ -23,7 +23,7 @@ export interface FileUploaderProps {
     openFileSelector: () => void;
   }) => React.ReactNode;
   onSuccess?: (data: UploadedFile) => void;
-  onFailure?: (error: unknown) => void;
+  onFailure?: (error: string) => void;
 }
 
 const FileUploader: React.FC<FileUploaderProps> = ({
@@ -146,7 +146,7 @@ const FileUploader: React.FC<FileUploaderProps> = ({
           }
         }
         setError(errorMessage);
-        onFailure?.(err);
+        onFailure?.(errorMessage);
       });
   };
 


### PR DESCRIPTION
## Description
- Updates onFailure to return the processed error instead of raw object

## Additional Information:
- The initial implementation was return the raw object after all the error processing, this forces the client to do the error handling, instead we can return the processed string. Which simplifies the error handling on client - I think this is what the author thought of but made a typo.

## Screenshot/Screencast
No change in UI and behaviour.

---

## Checklist

<!-- Check these after PR creation -->

- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
