### PR TITLE
Docs: Require discussion issue before new component PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,9 @@
+<!--
+⚠️ Adding a new component or feature?
+Please open an issue for discussion first and wait for it to be approved before
+starting work. PRs that add new components without a linked, approved issue may be closed.
+-->
+
 ## Description
 
 <!-- What do we want to achieve with this PR? -->
@@ -27,6 +33,7 @@ Please provide step-by-step instructions to test the changes.
 
 <!-- Check these after PR creation -->
 
+- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
 - [ ] I have thoroughly tested this code to the best of my abilities.
 - [ ] I have reviewed the code myself before requesting a review.
 - [ ] This code is covered by unit tests to verify that it works as intended.


### PR DESCRIPTION
## Description

Adds guidance to the PR template asking contributors to open a discussion issue and get it approved before starting work on a new component or feature. This should cut down on unsolicited PRs that add new components without prior alignment.

## Relevant Technical Choices

- Added a note at the top of the template (inside an HTML comment, so it shows while editing the PR description but stays out of the rendered body).
- Added a checklist item to confirm a new component has a linked, pre-approved issue.

## Testing Instructions


## Additional Information:

Documentation-only change to `.github/PULL_REQUEST_TEMPLATE.md`.

## Screenshot/Screencast

N/A

---

## Checklist

- [x] I have reviewed the code myself before requesting a review.
