### PR TITLE
Extend TabButton component

### DIFF
--- a/packages/frappe-ui-react/src/components/tabButtons/index.tsx
+++ b/packages/frappe-ui-react/src/components/tabButtons/index.tsx
@@ -24,6 +24,7 @@ interface TabButtonsProps {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  buttonClassName?: string;
 }
 
 const TabButtons = ({
@@ -31,6 +32,7 @@ const TabButtons = ({
   value,
   onChange,
   className = "",
+  buttonClassName = "",
 }: TabButtonsProps) => {
   return (
     <ToggleGroup
@@ -52,7 +54,8 @@ const TabButtons = ({
               "rounded-md px-2 outline-black group flex-1 h-6.5 w-full border border-transparent text-nowrap text-center",
               "hover:bg-surface-gray-3",
               "data-pressed:bg-surface-white data-pressed:border-outline-gray-2 data-pressed:hover:bg-surface-gray-4",
-              "disabled:text-ink-gray-5 disabled:hover:bg-surface-gray-2"
+              "disabled:text-ink-gray-5 disabled:hover:bg-surface-gray-2",
+              buttonClassName
             )}
             aria-label={button.label}
             value={button.value}


### PR DESCRIPTION
## Description
Extend the tabs button component to accept class names as prop. This enables us to style the tab buttons as per the redesign.

## Screenshot/Screencast
<img width="1072" height="166" alt="image" src="https://github.com/user-attachments/assets/f577918e-e438-40f2-b10a-a7d009c1804e" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).