### PR TITLE
Feat: Extend trigger for filter and multiselect

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -18,6 +18,7 @@ export const Filter: React.FC<FilterProps> = ({
   showCount = true,
   defaultOpen = false,
   align = "center",
+  triggerClassName,
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
@@ -103,9 +104,13 @@ export const Filter: React.FC<FilterProps> = ({
                       )
                     : undefined
                 }
-                className={cn("gap-2", {
-                  "rounded-r-none border-r-0": hasFilters,
-                })}
+                className={cn(
+                  "gap-2",
+                  {
+                    "rounded-r-none border-r-0": hasFilters,
+                  },
+                  triggerClassName
+                )}
               >
                 Filter
                 {showCount && hasFilters && (

--- a/packages/frappe-ui-react/src/components/filter/types.ts
+++ b/packages/frappe-ui-react/src/components/filter/types.ts
@@ -88,6 +88,8 @@ export interface FilterProps {
   defaultOpen?: boolean;
   /** Popover alignment relative to the trigger */
   align?: "start" | "center" | "end";
+  /** Custom class for the trigger button */
+  triggerClassName?: string;
 }
 
 /** Props for FilterRow component (internal) */

--- a/packages/frappe-ui-react/src/components/multiSelect/multiSelect.tsx
+++ b/packages/frappe-ui-react/src/components/multiSelect/multiSelect.tsx
@@ -23,6 +23,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   options,
   placeholder = "Select option",
   triggerLabel,
+  triggerClassName,
   hideSearch = false,
   open,
   loading = false,
@@ -94,7 +95,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           <Button
             className={cn(
               "w-full justify-between!",
-              !triggerLabel && value.length === 0 && "text-ink-gray-4!"
+              !triggerLabel && value.length === 0 && "text-ink-gray-4!",
+              triggerClassName
             )}
             iconRight={() => <ChevronDown className="w-4 h-4 shrink-0" />}
             aria-label="Select options"

--- a/packages/frappe-ui-react/src/components/multiSelect/types.ts
+++ b/packages/frappe-ui-react/src/components/multiSelect/types.ts
@@ -17,6 +17,8 @@ export interface MultiSelectProps {
   placeholder?: string;
   /** Fixed label always shown in the trigger button, overriding the selected values summary */
   triggerLabel?: string;
+  /** Additional class names for the trigger button */
+  triggerClassName?: string;
   /** Hide the search input in the dropdown */
   hideSearch?: boolean;
   /** Controlled open state for the popup */


### PR DESCRIPTION
## Description
- Adds trigger classes for filter button
- Adds trigger classes for multiselect

## Relevant Technical Choices
- This enables us to pass styles to buttons to match the figma.

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
