### PR TITLE
Fix: Update tabs styles

### DIFF
--- a/packages/frappe-ui-react/src/components/tabs/tabList.tsx
+++ b/packages/frappe-ui-react/src/components/tabs/tabList.tsx
@@ -20,7 +20,7 @@ export const TabList = ({ tabs, className }: TabListProps) => {
         <BaseTabs.Tab
           key={tab.label}
           className={cn(
-            "flex cursor-pointer items-center justify-center border-0 py-3 text-base tracking-wide whitespace-nowrap text-ink-gray-5 outline-outline-gray-4 select-none hover:text-ink-gray-8 data-selected:text-ink-gray-8 duration-300 ease-in-out",
+            "flex cursor-pointer items-center justify-center border-0 py-3 text-base tracking-wide whitespace-nowrap text-ink-gray-5 outline-outline-gray-4 select-none hover:text-ink-gray-8 data-active:text-ink-gray-8 data-selected:text-ink-gray-8 duration-300 ease-in-out",
             "data-[orientation=vertical]:justify-start data-[orientation=vertical]:px-4 data-[orientation=vertical]:py-2"
           )}
           value={tab.label}


### PR DESCRIPTION
## Description
- Updates styles for active tab
- We already had `data-selected:text-ink-gray-8` but this does not highlight the active tab.

## Screenshot/Screencast
<img width="1966" height="514" alt="image" src="https://github.com/user-attachments/assets/126ac154-8ffb-4934-a82c-d0c8669900ba" />


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).