### PR TITLE
enhancement: add render prop for sidebar items

### DIFF
--- a/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
@@ -11,7 +11,7 @@ import {
   Reports,
   Folder,
   Time,
-  People
+  People,
 } from "../../icons";
 
 const meta: Meta<typeof Sidebar> = {
@@ -163,6 +163,61 @@ export const SidebarExample: Story = {
             ...crmSidebar.header,
           }}
           sections={crmSidebar.sections}
+        />
+      </div>
+    );
+  },
+};
+
+/**
+ * A sidebar item can opt into a custom `render` prop (powered by base-ui's
+ * `useRender`) to replace the default button element. The item's internal
+ * props (`className` with active styling, `onClick`) and `state`
+ * (`active` / `collapsed`) are merged into whatever element you render.
+ */
+export const CustomItemRender: Story = {
+  render: () => {
+    return (
+      <div
+        className="flex h-screen w-full flex-col bg-surface-white shadow"
+        id="sidebar-container"
+      >
+        <Sidebar
+          header={{ ...crmSidebar.header }}
+          sections={[
+            {
+              label: "Navigation",
+              items: [
+                { label: "Home", icon: Home, to: "/", isActive: true },
+                {
+                  // `render` element — useRender merges className/onClick in.
+                  label: "Docs",
+                  icon: Folder,
+                  to: "/docs",
+                  render: (
+                    <a
+                      href="https://frappe.io"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Docs ↗
+                    </a>
+                  ),
+                },
+                {
+                  // `render` callback — receives merged props and item state.
+                  label: "Reports",
+                  icon: Reports,
+                  to: "/reports",
+                  render: (props, state) => (
+                    <a {...props} href="/reports">
+                      Reports {state.active ? "(active)" : ""}
+                    </a>
+                  ),
+                },
+              ],
+            },
+          ]}
         />
       </div>
     );

--- a/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebar.stories.tsx
@@ -169,12 +169,6 @@ export const SidebarExample: Story = {
   },
 };
 
-/**
- * A sidebar item can opt into a custom `render` prop (powered by base-ui's
- * `useRender`) to replace the default button element. The item's internal
- * props (`className` with active styling, `onClick`) and `state`
- * (`active` / `collapsed`) are merged into whatever element you render.
- */
 export const CustomItemRender: Story = {
   render: () => {
     return (

--- a/packages/frappe-ui-react/src/components/sidebar/sidebar.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebar.tsx
@@ -7,24 +7,25 @@ import React, { useState, useCallback } from "react";
  * Internal dependencies.
  */
 import SidebarHeader from "./sidebarHeader";
-import SidebarSection from "./sidebarSection";
+import SidebarSection, { type SidebarItem } from "./sidebarSection";
 import { useMediaQuery } from "./useMediaQuery";
 import { Divider } from "../divider";
 import { Button } from "../button";
 import { cn } from "../../utils";
 import Tooltip from "../tooltip/tooltip";
 import { MenuCollapse } from "../../icons";
+import type { DropdownOptions } from "../dropdown";
 
 export type SidebarHeaderProps = {
   title: string;
   subtitle?: string;
   logo?: React.ReactNode | string;
-  menuItems?: any[];
+  menuItems?: DropdownOptions;
 };
 
 export type SidebarSectionType = {
   label: string;
-  items: any[];
+  items: SidebarItem[];
   collapsible?: boolean;
 };
 

--- a/packages/frappe-ui-react/src/components/sidebar/sidebarHeader.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebarHeader.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import Dropdown from "../dropdown/dropdown";
 import FeatherIcon from "../featherIcon";
+import type { DropdownOptions } from "../dropdown";
 
 export type SidebarHeaderProps = {
   isCollapsed: boolean;
   title: string;
   subtitle?: string;
   logo?: React.ReactNode | string;
-  menuItems?: any[];
+  menuItems?: DropdownOptions;
   children?: React.ReactNode;
 };
 

--- a/packages/frappe-ui-react/src/components/sidebar/sidebarSection.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebarSection.tsx
@@ -3,18 +3,13 @@ import { LucideChevronDown } from "lucide-react";
 import { Collapsible } from "@base-ui/react/collapsible";
 
 import { cn } from "../../utils";
-import { Button } from "../button";
-import { Tooltip } from "../tooltip";
+import SidebarSectionItem, { type SidebarItem } from "./sidebarSectionItem";
+
+export type { SidebarItem, SidebarItemState } from "./sidebarSectionItem";
 
 export type SidebarSectionProps = {
   label: string;
-  items: {
-    label: string;
-    icon: React.ComponentType<{ className?: string }>;
-    to: string;
-    isActive: boolean;
-    onClick?: () => void;
-  }[];
+  items: SidebarItem[];
   collapsible?: boolean;
   sidebarCollapsed: boolean;
   activeItemClassName?: string;
@@ -33,39 +28,13 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
 
   if (!collapsible) {
     return items.map((item) => (
-      <Button
+      <SidebarSectionItem
         key={item.label}
-        onClick={item.onClick}
-        className={cn(
-          "w-full transition-all ease-in-out justify-start py-1 px-4 text-ink-gray-6",
-          {
-            "!bg-surface-selected shadow-sm": item.isActive,
-            "hover:bg-surface-gray-2": !item.isActive,
-            "px-2": sidebarCollapsed,
-          },
-          item.isActive && activeItemClassName
-        )}
-        variant="ghost"
-        iconLeft={() => (
-          <Tooltip
-            text={item.label}
-            placement="right"
-            disabled={!sidebarCollapsed}
-          >
-            <item.icon className="min-w-4 w-4 text-ink-gray-6" />
-          </Tooltip>
-        )}
-      >
-        {!sidebarCollapsed && (
-          <Tooltip text={item.label} placement="right" hoverDelay={1.5}>
-            <span
-              className={`flex-1 flex-shrink-0 truncate text-sm transition-all ease-in-out`}
-            >
-              {item.label}
-            </span>
-          </Tooltip>
-        )}
-      </Button>
+        item={item}
+        sidebarCollapsed={sidebarCollapsed}
+        activeItemClassName={activeItemClassName}
+        indentClassName="px-2"
+      />
     ));
   }
 
@@ -116,40 +85,14 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
           "space-y-0.5 flex flex-col align-start justify-between transition-all duration-150"
         )}
       >
-        {items.map((item: any) => (
-          <Button
+        {items.map((item) => (
+          <SidebarSectionItem
             key={item.label}
-            onClick={item.onClick}
-            className={cn(
-              "w-full transition-all ease-in-out justify-start py-1 pl-6 text-ink-gray-6",
-              {
-                "!bg-surface-selected shadow-sm": item.isActive,
-                "hover:bg-surface-gray-2": !item.isActive,
-                "px-2": sidebarCollapsed,
-              },
-              item.isActive && activeItemClassName
-            )}
-            variant="ghost"
-            iconLeft={() => (
-              <Tooltip
-                text={item.label}
-                placement="right"
-                disabled={!sidebarCollapsed}
-              >
-                <item.icon className="min-w-4 w-4 text-ink-gray-6" />
-              </Tooltip>
-            )}
-          >
-            {!sidebarCollapsed && (
-              <Tooltip text={item.label} placement="right" hoverDelay={1.5}>
-                <span
-                  className={`flex-1 flex-shrink-0 truncate text-sm transition-all ease-in-out`}
-                >
-                  {item.label}
-                </span>
-              </Tooltip>
-            )}
-          </Button>
+            item={item}
+            sidebarCollapsed={sidebarCollapsed}
+            activeItemClassName={activeItemClassName}
+            indentClassName="pl-6 pr-2"
+          />
         ))}
       </Collapsible.Panel>
     </Collapsible.Root>

--- a/packages/frappe-ui-react/src/components/sidebar/sidebarSectionItem.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebarSectionItem.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { useRender } from "@base-ui/react/use-render";
+
+import { cn } from "../../utils";
+import { Tooltip } from "../tooltip";
+
+export type SidebarItemState = {
+  active: boolean;
+  collapsed: boolean;
+};
+
+export type SidebarItem = {
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  to?: string;
+  isActive?: boolean;
+  onClick?: () => void;
+  /**
+   * Replace the default item element, or compose it with another component.
+   * Accepts a React element or a render function that receives the item's
+   * merged props (`className`, `onClick`, `children`) and its `state`.
+   */
+  render?: useRender.RenderProp<SidebarItemState>;
+};
+
+export type SidebarSectionItemProps = {
+  item: SidebarItem;
+  sidebarCollapsed: boolean;
+  activeItemClassName?: string;
+  indentClassName: string;
+};
+
+const SidebarSectionItem: React.FC<SidebarSectionItemProps> = ({
+  item,
+  sidebarCollapsed,
+  activeItemClassName,
+  indentClassName,
+}) => {
+  const state: SidebarItemState = {
+    active: Boolean(item.isActive),
+    collapsed: sidebarCollapsed,
+  };
+
+  const Icon = item.icon;
+
+  return useRender({
+    state,
+    render: item.render ?? <button type="button" />,
+    props: {
+      onClick: item.onClick,
+      className: cn(
+        "inline-flex h-7 w-full cursor-pointer items-center gap-2 rounded justify-start py-1 text-base text-left text-ink-gray-6 no-underline transition-all ease-in-out focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3",
+        indentClassName,
+        {
+          "!bg-surface-selected shadow-sm": item.isActive,
+          "hover:bg-surface-gray-2 active:bg-surface-gray-4": !item.isActive,
+          "px-2": sidebarCollapsed,
+        },
+        item.isActive && activeItemClassName
+      ),
+      children: (
+        <>
+          <Tooltip
+            text={item.label}
+            placement="right"
+            disabled={!sidebarCollapsed}
+          >
+            <Icon className="min-w-4 w-4 text-ink-gray-6" />
+          </Tooltip>
+          {!sidebarCollapsed && (
+            <Tooltip text={item.label} placement="right" hoverDelay={1.5}>
+              <span className="flex-1 flex-shrink-0 truncate text-base transition-all ease-in-out">
+                {item.label}
+              </span>
+            </Tooltip>
+          )}
+        </>
+      ),
+    },
+  });
+};
+
+export default SidebarSectionItem;


### PR DESCRIPTION
## Description

- Adds types for menu items and sidebar items in sidebar.
- Adds a render prop for sidebar items renderer
  - uses basUI's [useRender](https://base-ui.com/react/utils/use-render) hook to merge external and internal attributes.
  - This opens up ability to load custom elements like [Link](https://reactrouter.com/api/components/Link#prefetch) instead of button.

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
