### PR TITLE
feat(TextEditor): expose imperative API for precise list-item add/remove

### DIFF
--- a/packages/frappe-ui-react/src/components/textEditor/editorConfig.ts
+++ b/packages/frappe-ui-react/src/components/textEditor/editorConfig.ts
@@ -16,6 +16,7 @@ import { TableKit } from "@tiptap/extension-table";
 import "./extension/codeBlock.css";
 import type { TextEditorProps } from "./types";
 import { ExtendedCodeBlock } from "./extension/codeBlock";
+import { IdentifiedListItem } from "./extension/identifiedListItem";
 
 export const DEFAULT_EDITOR_CLASS =
   "ProseMirror prose prose-table:table-fixed prose-td:p-2 prose-th:p-2 prose-td:border prose-th:border prose-td:border-outline-gray-2 prose-th:border-outline-gray-2 prose-td:relative prose-th:relative prose-th:bg-surface-gray-2 border-outline-gray-1";
@@ -37,6 +38,7 @@ export const getTextEditorExtensions = ({
 }: EditorExtensionOptions): Extensions => [
   StarterKit.configure({
     codeBlock: false,
+    listItem: false,
     horizontalRule: {
       HTMLAttributes: {
         class: "not-prose border-outline-gray-1 m-0",
@@ -59,5 +61,6 @@ export const getTextEditorExtensions = ({
   Highlight.configure({ multicolor: true }),
   TableKit,
   ExtendedCodeBlock,
+  IdentifiedListItem,
   ...extensions,
 ];

--- a/packages/frappe-ui-react/src/components/textEditor/extension/identifiedListItem.ts
+++ b/packages/frappe-ui-react/src/components/textEditor/extension/identifiedListItem.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies.
+ */
+import { ListItem } from "@tiptap/extension-list";
+
+export const IdentifiedListItem = ListItem.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      itemId: {
+        default: null,
+        parseHTML: (element) => element.getAttribute("data-item-id"),
+        renderHTML: (attributes) =>
+          attributes.itemId ? { "data-item-id": attributes.itemId } : {},
+      },
+    };
+  },
+});

--- a/packages/frappe-ui-react/src/components/textEditor/extension/utils.ts
+++ b/packages/frappe-ui-react/src/components/textEditor/extension/utils.ts
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/react";
+import type { Node } from "@tiptap/pm/model";
 
 export function lineStartsBetween(
   text: string,
@@ -35,3 +36,42 @@ export function getCodeBlockCtx(state: Editor["state"]) {
 }
 
 export const INDENT = " ".repeat(4);
+
+type FoundListItem = { pos: number; node: Node };
+
+export const findListItemById = (
+  editor: Editor,
+  id: string
+): FoundListItem | null => {
+  let found: FoundListItem | null = null;
+  editor.state.doc.descendants((node: Node, pos: number) => {
+    if (node.type.name === "listItem" && node.attrs.itemId === id) {
+      found = { pos, node };
+    }
+  });
+  return found;
+};
+
+export const findIdentifiedBulletListEnd = (editor: Editor) => {
+  let endPos: number | null = null;
+  editor.state.doc.descendants((node: Node, pos: number) => {
+    if (node.type.name !== "bulletList") return;
+    let hasIdentifiedItem = false;
+    node.forEach((child: Node) => {
+      if (child.attrs.itemId) hasIdentifiedItem = true;
+    });
+    if (hasIdentifiedItem) {
+      endPos = pos + node.nodeSize - 1;
+    }
+  });
+  return endPos;
+};
+
+export const isDocEmpty = (editor: Editor) => {
+  const { doc } = editor.state;
+  return (
+    doc.childCount === 1 &&
+    doc.firstChild?.type.name === "paragraph" &&
+    doc.firstChild.content.size === 0
+  );
+};

--- a/packages/frappe-ui-react/src/components/textEditor/textEditor.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/textEditor.interactions.stories.tsx
@@ -1,6 +1,8 @@
+import { useRef } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { screen, userEvent, expect, within } from "storybook/test";
 import TextEditor from "./textEditor";
+import type { TextEditorHandle } from "./types";
 
 const meta: Meta<typeof TextEditor> = {
   title: "Components/TextEditor/Interactions",
@@ -253,5 +255,87 @@ export const EditorFontColor: Story = {
     expect(newText).toHaveStyle("color: rgb(204, 41, 41)");
     expect(newText.tagName).toBe("MARK");
     expect(newText).toHaveStyle("background-color: #ffe7e7");
+  },
+};
+
+export const EditorListItemHandle: Story = {
+  args: {
+    editorClass: "prose-sm min-h-[4rem] border rounded-b-lg border-t-0 p-2",
+  },
+  render: function ListItemHandleRender(args) {
+    const ref = useRef<TextEditorHandle>(null);
+    return (
+      <div className="m-2 w-[550px]">
+        <TextEditor {...args} ref={ref} />
+        <div className="mt-2 flex gap-2">
+          <button
+            type="button"
+            onClick={() => ref.current?.addListItem("item-1", "First item")}
+          >
+            Add Item 1
+          </button>
+          <button
+            type="button"
+            onClick={() => ref.current?.addListItem("item-2", "Second item")}
+          >
+            Add Item 2
+          </button>
+          <button
+            type="button"
+            onClick={() => ref.current?.removeListItem("item-1")}
+          >
+            Remove Item 1
+          </button>
+          <button
+            type="button"
+            onClick={() => ref.current?.removeListItem("item-2")}
+          >
+            Remove Item 2
+          </button>
+        </div>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Adding the first item on a blank editor should create a new list,
+    // replacing the placeholder paragraph instead of appending after it.
+    await userEvent.click(canvas.getByRole("button", { name: "Add Item 1" }));
+
+    let item1 = canvasElement.querySelector('li[data-item-id="item-1"]');
+    expect(item1).not.toBeNull();
+    expect(item1?.textContent).toBe("First item");
+    expect(canvasElement.querySelectorAll("ul").length).toBe(1);
+
+    // Adding a second item should append to the existing tagged list.
+    await userEvent.click(canvas.getByRole("button", { name: "Add Item 2" }));
+
+    expect(canvasElement.querySelectorAll("ul").length).toBe(1);
+    expect(canvasElement.querySelectorAll("li").length).toBe(2);
+
+    const item2 = canvasElement.querySelector('li[data-item-id="item-2"]');
+    expect(item2).not.toBeNull();
+    expect(item2?.textContent).toBe("Second item");
+
+    // Removing one of two items should only delete that item, leaving the
+    // wrapping list intact.
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Remove Item 1" })
+    );
+
+    item1 = canvasElement.querySelector('li[data-item-id="item-1"]');
+    expect(item1).toBeNull();
+    expect(canvasElement.querySelectorAll("li").length).toBe(1);
+    expect(canvasElement.querySelectorAll("ul").length).toBe(1);
+
+    // Removing the last remaining item should also remove the now-empty
+    // wrapping list, leaving no leftover empty list behind.
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Remove Item 2" })
+    );
+
+    expect(canvasElement.querySelectorAll("li").length).toBe(0);
+    expect(canvasElement.querySelectorAll("ul").length).toBe(0);
   },
 };

--- a/packages/frappe-ui-react/src/components/textEditor/textEditor.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/textEditor.tsx
@@ -2,13 +2,14 @@
  * External dependencies.
  */
 import { EditorContent, EditorContext, useEditor } from "@tiptap/react";
-import { useMemo } from "react";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { forwardRef, useImperativeHandle, useMemo } from "react";
 
 /**
  * Internal dependencies.
  */
 import "./textEditor.css";
-import type { TextEditorProps } from "./types";
+import type { TextEditorHandle, TextEditorProps } from "./types";
 import FixedMenu from "./menu/fixedMenu";
 import { cn } from "../../utils";
 import {
@@ -17,65 +18,146 @@ import {
   EMPTY_STARTERKIT_OPTIONS,
   getTextEditorExtensions,
 } from "./editorConfig";
+import {
+  findIdentifiedBulletListEnd,
+  findListItemById,
+  isDocEmpty,
+} from "./extension/utils";
 
-const TextEditor = ({
-  content,
-  placeholder = "",
-  editorClass = "",
-  editable = true,
-  autofocus = false,
-  extensions = EMPTY_EXTENSIONS,
-  starterkitOptions = EMPTY_STARTERKIT_OPTIONS,
-  fixedMenu = false,
-  onChange,
-  onFocus,
-  onBlur,
-  onTransaction,
-  Top,
-  Editor,
-  Bottom,
-}: TextEditorProps) => {
-  const editorExtensions = useMemo(
-    () =>
-      getTextEditorExtensions({ extensions, starterkitOptions, placeholder }),
-    [extensions, starterkitOptions, placeholder]
-  );
-
-  const editor = useEditor(
+const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
+  function TextEditor(
     {
       content,
-      editable,
-      autofocus,
-      editorProps: {
-        attributes: {
-          class: cn(DEFAULT_EDITOR_CLASS, editorClass),
+      placeholder = "",
+      editorClass = "",
+      editable = true,
+      autofocus = false,
+      extensions = EMPTY_EXTENSIONS,
+      starterkitOptions = EMPTY_STARTERKIT_OPTIONS,
+      fixedMenu = false,
+      onChange,
+      onFocus,
+      onBlur,
+      onTransaction,
+      Top,
+      Editor,
+      Bottom,
+    },
+    ref
+  ) {
+    const editorExtensions = useMemo(
+      () =>
+        getTextEditorExtensions({ extensions, starterkitOptions, placeholder }),
+      [extensions, starterkitOptions, placeholder]
+    );
+
+    const editor = useEditor(
+      {
+        content,
+        editable,
+        autofocus,
+        editorProps: {
+          attributes: {
+            class: cn(DEFAULT_EDITOR_CLASS, editorClass),
+          },
+        },
+        extensions: editorExtensions,
+        onUpdate: ({ editor }) => {
+          onChange?.(editor.getHTML());
+        },
+        onFocus: ({ event }) => {
+          onFocus?.(event);
+        },
+        onBlur: ({ event }) => {
+          onBlur?.(event);
+        },
+        onTransaction: ({ editor }) => {
+          onTransaction?.(editor);
         },
       },
-      extensions: editorExtensions,
-      onUpdate: ({ editor }) => {
-        onChange?.(editor.getHTML());
-      },
-      onFocus: ({ event }) => {
-        onFocus?.(event);
-      },
-      onBlur: ({ event }) => {
-        onBlur?.(event);
-      },
-      onTransaction: ({ editor }) => {
-        onTransaction?.(editor);
-      },
-    },
-    [editable, autofocus, editorClass, editorExtensions]
-  );
+      [editable, autofocus, editorClass, editorExtensions]
+    );
 
-  return (
-    <EditorContext.Provider value={{ editor }}>
-      {Top && <Top />}
-      {fixedMenu && <FixedMenu />}
-      {Editor ? <Editor editor={editor} /> : <EditorContent editor={editor} />}
-      {Bottom && <Bottom />}
-    </EditorContext.Provider>
-  );
-};
+    useImperativeHandle(
+      ref,
+      () => ({
+        addListItem: (id, text) => {
+          if (!editor) return;
+
+          const listItemContent = {
+            type: "listItem",
+            attrs: { itemId: id },
+            content: [
+              {
+                type: "paragraph",
+                content: text ? [{ type: "text", text }] : [],
+              },
+            ],
+          };
+
+          const listEndPos = findIdentifiedBulletListEnd(editor);
+
+          if (listEndPos !== null) {
+            editor.chain().insertContentAt(listEndPos, listItemContent).run();
+          } else {
+            const { doc } = editor.state;
+
+            // On a blank editor, replace the placeholder paragraph instead of
+            // inserting after it - otherwise the list ends up under a stray
+            // leading blank line.
+            const range = isDocEmpty(editor)
+              ? { from: 0, to: doc.content.size }
+              : { from: doc.content.size, to: doc.content.size };
+
+            editor
+              .chain()
+              .insertContentAt(range, {
+                type: "bulletList",
+                content: [listItemContent],
+              })
+              .run();
+          }
+        },
+        removeListItem: (id) => {
+          if (!editor) return;
+
+          const found = findListItemById(editor, id);
+          if (!found) return;
+
+          const itemPos: number = found.pos;
+          const itemNode: ProseMirrorNode = found.node;
+          const parent = editor.state.doc.resolve(itemPos).parent;
+
+          if (parent.type.name === "bulletList" && parent.childCount === 1) {
+            const listStart = editor.state.doc.resolve(itemPos).before();
+            editor
+              .chain()
+              .deleteRange({ from: listStart, to: listStart + parent.nodeSize })
+              .run();
+          } else {
+            editor
+              .chain()
+              .deleteRange({ from: itemPos, to: itemPos + itemNode.nodeSize })
+              .run();
+          }
+        },
+      }),
+      [editor]
+    );
+
+    return (
+      <EditorContext.Provider value={{ editor }}>
+        {Top && <Top />}
+        {fixedMenu && <FixedMenu />}
+        {Editor ? (
+          <Editor editor={editor} />
+        ) : (
+          <EditorContent editor={editor} />
+        )}
+        {Bottom && <Bottom />}
+      </EditorContext.Provider>
+    );
+  }
+);
 
 export default TextEditor;

--- a/packages/frappe-ui-react/src/components/textEditor/types.ts
+++ b/packages/frappe-ui-react/src/components/textEditor/types.ts
@@ -44,3 +44,8 @@ export interface EditorCommand {
     }) => React.ReactNode;
   }>;
 }
+
+export interface TextEditorHandle {
+  addListItem: (id: string, text: string) => void;
+  removeListItem: (id: string) => void;
+}


### PR DESCRIPTION
## Description
- Add TextEditorHandle ref interface (addListItem, removeListItem) via forwardRef + useImperativeHandle, so consumers can mutate list items on the live editor.
- Add IdentifiedListItem extension (ListItem.extend) that tags list items with a persisted itemId attribute (data-item-id), registered in place of StarterKit's default listItem
- Add findListItemById, findIdentifiedBulletListEnd, isDocEmpty helpers in extension/utils.ts for locating tagged nodes and checking blank-doc state
- addListItem: appends to an existing tagged list if one exists; otherwise creates a new list, replacing the placeholder paragraph if the doc is empty (avoids a stray leading blank line)
- removeListItem: deletes the specific tagged <li> by id; deletes the whole wrapping <ul> if it was the last item (avoids leftover empty lists)

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).