### PR TITLE
Fix: Close filter popover when all filters are removed

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -61,6 +61,9 @@ export const Filter: React.FC<FilterProps> = ({
     (index: number) => {
       const newFilters = value.filter((_, i) => i !== index);
       onChange?.(newFilters);
+      if (newFilters.length === 0) {
+        setIsOpen(false);
+      }
     },
     [value, onChange]
   );
@@ -70,6 +73,7 @@ export const Filter: React.FC<FilterProps> = ({
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.stopPropagation();
       onChange?.([]);
+      setIsOpen(false);
     },
     [onChange]
   );


### PR DESCRIPTION
## Description

The filters popover was not automatically closing when all the active filters were removed.

## Testing Instructions

- Go to Timesheets.
- Click on the Filter button and add filters.
- Remove all applied filters using the remove all (✕) button.
- The modal should automatically close after filters are removed. 

## Screenshot/Screencast



https://github.com/user-attachments/assets/021c1fc1-d87d-41ee-8ce6-ee7fdc244268



---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Part of: https://github.com/rtCamp/next-pms/issues/1603
