### PR TITLE
Feat: Add support for Link field type in filters

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Filter } from "./index";
-import type { FilterCondition, FilterField } from "./types";
+import { Combobox } from "../combobox";
+import type {
+  FilterCondition,
+  FilterField,
+  FilterLinkValueRenderProps,
+} from "./types";
 import { TextInput } from "../textInput";
 
 const meta: Meta<typeof Filter> = {
@@ -111,6 +116,12 @@ const sampleFields: FilterField[] = [
     label: "Assignee",
     type: "select",
     options: assigneeOptions,
+  },
+  {
+    name: "customer_link",
+    label: "Customer (Link)",
+    type: "link",
+    link: { doctype: "User", labelField: "full_name" },
   },
   {
     name: "title",
@@ -279,4 +290,52 @@ export const WithExternalFilters: Story = {
   args: {
     fields: sampleFields,
   },
+};
+
+export const LinkField: Story = {
+  render: (args) => <FilterWithState {...args} />,
+  args: {
+    fields: sampleFields,
+    renderLinkValue: (props) => <MockLinkValue {...props} />,
+  },
+};
+
+const mockLinkRecords: Record<string, Record<string, string>[]> = {
+  User: [
+    { name: "john", full_name: "John Doe" },
+    { name: "jane", full_name: "Jane Smith" },
+    { name: "bob", full_name: "Bob Wilson" },
+    { name: "alice", full_name: "Alice Johnson" },
+  ],
+};
+
+const MockLinkValue: React.FC<FilterLinkValueRenderProps> = ({
+  field,
+  value,
+  onChange,
+  disabled,
+}) => {
+  const link = field.link!;
+  const labelField = link.labelField ?? "name";
+  const valueField = link.valueField ?? "name";
+
+  const options = React.useMemo(() => {
+    const records = mockLinkRecords[link.doctype] ?? [];
+    return records.map((r) => ({
+      label: r[labelField] ?? r[valueField],
+      value: r[valueField],
+    }));
+  }, [link.doctype, labelField, valueField]);
+
+  return (
+    <Combobox
+      options={options}
+      value={value}
+      openOnFocus
+      disabled={disabled}
+      placeholder="Value"
+      onChange={(val) => onChange(val)}
+      className="w-auto"
+    />
+  );
 };

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -19,6 +19,7 @@ export const Filter: React.FC<FilterProps> = ({
   defaultOpen = false,
   align = "center",
   triggerClassName,
+  renderLinkValue,
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
@@ -154,6 +155,7 @@ export const Filter: React.FC<FilterProps> = ({
                     fields={fields}
                     onChange={(updated) => handleFilterChange(index, updated)}
                     onRemove={() => handleRemoveFilter(index)}
+                    renderLinkValue={renderLinkValue}
                     isFirst={index === 0}
                   />
                 ))}

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -8,6 +8,7 @@ import type {
   FilterRowProps,
   FilterOperatorOption,
   FilterSelectOption,
+  FilterLinkValueRenderProps,
 } from "./types";
 
 const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
@@ -39,6 +40,10 @@ const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
     { label: "is not empty", value: "is_not_empty", hideValue: true },
   ],
   daterange: [{ label: "Between", value: "between" }],
+  link: [
+    { label: "Equals", value: "=" },
+    { label: "Not Equals", value: "!=" },
+  ],
   default: [
     { label: "is", value: "is" },
     { label: "is not", value: "is_not" },
@@ -50,6 +55,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
   fields,
   onChange,
   onRemove,
+  renderLinkValue,
   isFirst = false,
 }) => {
   // Get the selected field
@@ -207,6 +213,14 @@ export const FilterRow: React.FC<FilterRowProps> = ({
               )}
             </DateRangePicker>
           );
+        } else if (selectedField?.type === "link" && renderLinkValue) {
+          const linkValueProps: FilterLinkValueRenderProps = {
+            field: selectedField,
+            value: typeof filter.value === "string" ? filter.value : null,
+            onChange: (v) => handleValueChange(v),
+            disabled: !filter.operator,
+          };
+          return renderLinkValue(linkValueProps);
         } else if (valueOptions.length > 0) {
           return (
             <FilterSelect

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -43,6 +43,8 @@ const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
   link: [
     { label: "Equals", value: "=" },
     { label: "Not Equals", value: "!=" },
+    { label: "Like", value: "like" },
+    { label: "Not Like", value: "not like" },
   ],
   default: [
     { label: "is", value: "is" },

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -45,6 +45,7 @@ const DEFAULT_OPERATORS: Record<string, FilterOperatorOption[]> = {
     { label: "Not Equals", value: "!=" },
     { label: "Like", value: "like" },
     { label: "Not Like", value: "not like" },
+    { label: "is", value: "is" },
   ],
   default: [
     { label: "is", value: "is" },
@@ -214,6 +215,21 @@ export const FilterRow: React.FC<FilterRowProps> = ({
                 />
               )}
             </DateRangePicker>
+          );
+        } else if (selectedField?.type === "link" && filter.operator === "is") {
+          const setOptions: FilterSelectOption[] = [
+            { label: "Set", value: "is_set" },
+            { label: "Not set", value: "is_not_set" },
+          ];
+          return (
+            <FilterSelect
+              value={typeof filter.value === "string" ? filter.value : null}
+              options={setOptions}
+              onChange={handleValueChange}
+              placeholder="Value"
+              minWidth={140}
+              disabled={!filter.operator}
+            />
           );
         } else if (selectedField?.type === "link" && renderLinkValue) {
           const linkValueProps: FilterLinkValueRenderProps = {

--- a/packages/frappe-ui-react/src/components/filter/types.ts
+++ b/packages/frappe-ui-react/src/components/filter/types.ts
@@ -38,6 +38,16 @@ export interface FilterOperatorOption {
   hideValue?: boolean;
 }
 
+/** Configuration for a Link-type filter field. */
+export interface FilterLinkConfig {
+  /** Target doctype to fetch documents from. */
+  doctype: string;
+  /** Field on the target doctype to use as the option label. */
+  labelField?: string;
+  /** Field on the target doctype whose value is stored as the filter value. */
+  valueField?: string;
+}
+
 /** Field definition for what can be filtered */
 export interface FilterField {
   /** The category of the field being filtered */
@@ -47,13 +57,34 @@ export interface FilterField {
   /** Display label */
   label: string;
   /** Field type determines available operators and value input */
-  type?: "string" | "number" | "date" | "daterange" | "select" | "multiselect";
+  type?:
+    | "string"
+    | "number"
+    | "date"
+    | "daterange"
+    | "select"
+    | "multiselect"
+    | "link";
   /** Available operators for this field (defaults based on type) */
   operators?: FilterOperatorOption[];
   /** Options for select/multiselect type fields */
   options?: FilterOptionType[];
+  /** Link configuration for fields with `type: "link"`. */
+  link?: FilterLinkConfig;
   /** Custom icon for the field */
   icon?: ReactNode;
+}
+
+/** Props supplied to `renderLinkValue` when a link-type field renders its value cell. */
+export interface FilterLinkValueRenderProps {
+  /** The field definition */
+  field: FilterField;
+  /** Current value (the linked document name). */
+  value: string | null;
+  /** Callback to update the value. */
+  onChange: (value: string | null) => void;
+  /** Whether the value input should be disabled. */
+  disabled?: boolean;
 }
 
 /** A single filter condition */
@@ -90,6 +121,8 @@ export interface FilterProps {
   align?: "start" | "center" | "end";
   /** Custom class for the trigger button */
   triggerClassName?: string;
+  /** Render-prop for the value cell of `type: "link"` fields. */
+  renderLinkValue?: (props: FilterLinkValueRenderProps) => ReactNode;
 }
 
 /** Props for FilterRow component (internal) */
@@ -102,6 +135,8 @@ export interface FilterRowProps {
   onChange: (filter: FilterCondition) => void;
   /** Callback when filter is removed */
   onRemove: () => void;
+  /** Render-prop for the value cell of `type: "link"` fields. */
+  renderLinkValue?: (props: FilterLinkValueRenderProps) => ReactNode;
   /** Whether this is the first row */
   isFirst?: boolean;
 }


### PR DESCRIPTION
## Description

Adds support for link field type in the filter component, with link options and render props to populate the link field types with options for that doctype.

## Screenshot/Screencast


- Wired to "Reporting Manager" in allocations Team page


https://github.com/user-attachments/assets/ffc9feeb-d56e-4f82-a663-6c9904ff1c1d


- Wired to "Customer" in allocations Projects page


https://github.com/user-attachments/assets/32c2f0c6-40bf-4dd4-af91-719c61f221f1

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).


Part of: https://github.com/rtCamp/next-pms/issues/1338
