### PR TITLE
Add support for external filter count and clear all in filter component

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Filter } from "./index";
 import type { FilterCondition, FilterField } from "./types";
+import { TextInput } from "../textInput";
 
 const meta: Meta<typeof Filter> = {
   title: "Components/Filter",
@@ -39,6 +40,16 @@ const meta: Meta<typeof Filter> = {
     defaultOpen: {
       control: "boolean",
       description: "Whether the filter panel is open by default",
+    },
+    externalFilterCount: {
+      control: "number",
+      description:
+        "Count of filters managed outside this component (e.g. standalone quick filters) — folded into the active-filter count so 'Clear all' shows even when `value` is empty",
+    },
+    onClearAll: {
+      action: "cleared-all",
+      description:
+        "Called when the user clicks 'Clear all', in addition to onChange([]) — use to reset any externally-managed filters. Not called for row-by-row removal.",
     },
   },
 };
@@ -230,5 +241,42 @@ export const DefaultOpen: Story = {
   args: {
     fields: sampleFields,
     defaultOpen: true,
+  },
+};
+
+const WithExternalFilterState = (args: React.ComponentProps<typeof Filter>) => {
+  const [search, setSearch] = React.useState("");
+  const [filters, setFilters] = React.useState<FilterCondition[]>(
+    args.value || []
+  );
+
+  return (
+    <div className="flex items-center gap-2">
+      <TextInput
+        placeholder="Search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      <Filter
+        {...args}
+        value={filters}
+        onChange={(newFilters) => {
+          setFilters(newFilters);
+          args.onChange?.(newFilters);
+        }}
+        externalFilterCount={search ? 1 : 0}
+        onClearAll={() => {
+          setSearch("");
+          args.onClearAll?.();
+        }}
+      />
+    </div>
+  );
+};
+
+export const WithExternalFilters: Story = {
+  render: (args) => <WithExternalFilterState {...args} />,
+  args: {
+    fields: sampleFields,
   },
 };

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -25,7 +25,11 @@ export const Filter: React.FC<FilterProps> = ({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   // Get the active filter count
-  const filterCount = value.length + externalFilterCount;
+  const safeExternalFilterCount =
+    Number.isFinite(externalFilterCount) && externalFilterCount > 0
+      ? externalFilterCount
+      : 0;
+  const filterCount = value.length + safeExternalFilterCount;
   const hasFilters = filterCount > 0;
 
   // Create a new empty filter

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -19,11 +19,13 @@ export const Filter: React.FC<FilterProps> = ({
   defaultOpen = false,
   align = "center",
   triggerClassName,
+  externalFilterCount = 0,
+  onClearAll,
 }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   // Get the active filter count
-  const filterCount = value.length;
+  const filterCount = value.length + externalFilterCount;
   const hasFilters = filterCount > 0;
 
   // Create a new empty filter
@@ -74,8 +76,9 @@ export const Filter: React.FC<FilterProps> = ({
       e.stopPropagation();
       onChange?.([]);
       setIsOpen(false);
+      onClearAll?.();
     },
-    [onChange]
+    [onChange, onClearAll]
   );
 
   // Handle popover open - add initial filter if empty

--- a/packages/frappe-ui-react/src/components/filter/types.ts
+++ b/packages/frappe-ui-react/src/components/filter/types.ts
@@ -90,6 +90,10 @@ export interface FilterProps {
   align?: "start" | "center" | "end";
   /** Custom class for the trigger button */
   triggerClassName?: string;
+  /** Count of filters managed outside this component */
+  externalFilterCount?: number;
+  /** Called when the user clicks "Clear all" */
+  onClearAll?: () => void;
 }
 
 /** Props for FilterRow component (internal) */


### PR DESCRIPTION
# Description
- Filter now accepts two optional props: externalFilterCount (folds outside-managed filters into the active count so "Clear all" shows even when value is empty) and onClearAll (fires only from the "Clear all" button).
- Added a WithExternalFilters Storybook story demonstrating the pattern.

## Screenshot/Screencast
<img width="1044" height="424" alt="image" src="https://github.com/user-attachments/assets/fe5530ea-ad69-4ad4-8cc2-92859b632705" />

<img width="1452" height="592" alt="image" src="https://github.com/user-attachments/assets/cbbb69b6-967f-417a-9b7f-43e501b5dbe4" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
