### PR TITLE
fix(filter): open dropdown on click anywhere in the trigger

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -141,6 +141,7 @@ export const Filter: React.FC<FilterProps> = ({
         <Popover.Portal>
           <Popover.Positioner sideOffset={4} align={align}>
             <Popover.Popup
+              initialFocus={false}
               className={cn(
                 "rounded-lg border shadow-xl bg-surface-modal border-outline-gray-1",
                 "p-1 min-w-100 max-w-150 animate-fade-in z-100"

--- a/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
@@ -109,6 +109,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
       value={value ?? ""}
       onChange={handleChange}
       disabled={disabled}
+      immediate
     >
       <div className={cn("relative", className)} style={style}>
         <div className="relative w-full">


### PR DESCRIPTION
## Description
Fixes FilterSelect so clicking the input area opens the dropdown, not just the chevron icon. Also fixes a regression this caused where opening the Filter popover auto-opened the first field's dropdown (due to Base UI auto-focusing it) - disabled that initial focus so the panel opens clean.

## Screenshot/Screencast
<img width="1156" height="360" alt="image" src="https://github.com/user-attachments/assets/09316dd7-530e-416b-bc9a-ee32113d2a39" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).