### PR TITLE
Feat: Add support for floating values to DurationInput

### DIFF
--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
@@ -104,17 +104,31 @@ export const Input: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole("textbox");
+    const enterDuration = async (
+      duration: string,
+      expectedChange: number,
+      expectedValue: string
+    ) => {
+      await userEvent.click(input);
+      await userEvent.clear(input);
+      await userEvent.type(input, duration);
+
+      await waitFor(() => {
+        expect(input).toHaveValue(duration);
+      });
+
+      await userEvent.tab();
+
+      await waitFor(() => {
+        expect(args.onChange).toHaveBeenCalledWith(expectedChange);
+        expect(input).toHaveValue(expectedValue);
+      });
+    };
+
+    await enterDuration("1", 1, "01:00");
 
     await userEvent.click(input);
-    await userEvent.type(input, "1");
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(args.onChange).toHaveBeenCalledWith(1);
-      expect(input).toHaveValue("01:00");
-    });
-
-    await userEvent.click(input);
+    await userEvent.clear(input);
     await userEvent.type(input, "7");
     await userEvent.keyboard("{Escape}");
 
@@ -124,19 +138,12 @@ export const Input: Story = {
 
     expect(args.onChange).toHaveBeenCalledTimes(1);
 
-    await userEvent.click(input);
-    await userEvent.type(input, "1.5");
-
-    await waitFor(() => {
-      expect(input).toHaveValue("1.5");
-    });
-
-    await userEvent.tab();
-
-    await waitFor(() => {
-      expect(args.onChange).toHaveBeenCalledWith(1.5);
-      expect(input).toHaveValue("01:30");
-    });
+    await enterDuration("1.5", 1.5, "01:30");
+    await enterDuration("5:3", 5.05, "05:03");
+    await enterDuration(".5", 0.5, "00:30");
+    await enterDuration(":30", 0.5, "00:30");
+    await enterDuration("5:", 5, "05:00");
+    await enterDuration("1:75", 2.25, "02:15");
   },
 };
 

--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
@@ -106,7 +106,6 @@ export const Input: Story = {
     const input = canvas.getByRole("textbox");
 
     await userEvent.click(input);
-    await userEvent.clear(input);
     await userEvent.type(input, "1");
     await userEvent.tab();
 
@@ -116,7 +115,6 @@ export const Input: Story = {
     });
 
     await userEvent.click(input);
-    await userEvent.clear(input);
     await userEvent.type(input, "7");
     await userEvent.keyboard("{Escape}");
 
@@ -125,6 +123,20 @@ export const Input: Story = {
     });
 
     expect(args.onChange).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(input);
+    await userEvent.type(input, "1.5");
+
+    await waitFor(() => {
+      expect(input).toHaveValue("1.5");
+    });
+
+    await userEvent.tab();
+
+    await waitFor(() => {
+      expect(args.onChange).toHaveBeenCalledWith(1.5);
+      expect(input).toHaveValue("01:30");
+    });
   },
 };
 

--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
@@ -362,7 +362,7 @@ const DurationInput = ({
         <input
           type="text"
           id={sliderId}
-          inputMode="numeric"
+          inputMode="decimal"
           className={cn(
             durationInputVariants({ size, disabled, error }),
             classNames.input
@@ -370,9 +370,10 @@ const DurationInput = ({
           placeholder="00:00"
           value={inputVal}
           disabled={disabled}
-          onFocus={() => {
+          onFocus={(e) => {
             setDraftValue(floatToTime(value));
             setDragValue(null);
+            e.currentTarget.select();
           }}
           onChange={(e) => {
             setDraftValue(sanitizeHoursInput(e.target.value));

--- a/packages/frappe-ui-react/src/components/durationInput/utils.ts
+++ b/packages/frappe-ui-react/src/components/durationInput/utils.ts
@@ -151,13 +151,13 @@ export const normalizeCommittedHours = (
 };
 
 /**
- * Filters text input down to characters valid for `HH:MM`.
+ * Filters text input down to characters valid for decimal hours or `HH:MM`.
  *
  * @param value - Raw input value.
  * @returns Sanitized input string.
  */
 export const sanitizeHoursInput = (value: string): string => {
-  return value.replace(/[^0-9:]/g, "");
+  return value.replace(/[^0-9:.]/g, "");
 };
 
 /**

--- a/packages/frappe-ui-react/src/components/durationInput/utils.ts
+++ b/packages/frappe-ui-react/src/components/durationInput/utils.ts
@@ -27,7 +27,7 @@ export function floatToTime(
 
 /**
  * Converts a duration string to decimal hours.
- * Accepts either decimal input or `HH:MM`.
+ * Accepts decimal hours or `HH:MM`-style duration input.
  *
  * @param value - Duration string to parse.
  * @returns Duration in hours.
@@ -35,25 +35,20 @@ export function floatToTime(
 export const timeToFloat = (value: string): number => {
   const trimmedValue = value.trim();
 
-  if (/^\d+(\.\d+)?$/.test(trimmedValue)) {
+  if (/^(\d+(\.\d*)?|\.\d+)$/.test(trimmedValue)) {
     return Number(trimmedValue);
   }
 
-  const hhmmMatch = /^([0-9]{1,2}):([0-9]{2})$/.exec(trimmedValue);
+  const hhmmMatch = /^([0-9]*):([0-9]*)$/.exec(trimmedValue);
 
-  if (!hhmmMatch) {
+  if (!hhmmMatch || (!hhmmMatch[1] && !hhmmMatch[2])) {
     return 0;
   }
 
-  const hours = Number(hhmmMatch[1]);
-  const minutes = Number(hhmmMatch[2]);
+  const hours = Number(hhmmMatch[1] || 0);
+  const minutes = Number(hhmmMatch[2] || 0);
 
-  if (
-    Number.isNaN(hours) ||
-    Number.isNaN(minutes) ||
-    minutes < 0 ||
-    minutes > 59
-  ) {
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
     return 0;
   }
 
@@ -157,7 +152,24 @@ export const normalizeCommittedHours = (
  * @returns Sanitized input string.
  */
 export const sanitizeHoursInput = (value: string): string => {
-  return value.replace(/[^0-9:.]/g, "");
+  const sanitizedValue = value.replace(/[^0-9:.]/g, "");
+
+  // If the input contains a colon, treat it as `HH:MM` and remove any periods.
+  if (sanitizedValue.includes(":")) {
+    const [hours = "", ...minuteParts] = sanitizedValue
+      .replace(/\./g, "")
+      .split(":");
+
+    return `${hours}:${minuteParts.join("")}`;
+  }
+
+  const [hours = "", ...decimalParts] = sanitizedValue.split(".");
+
+  if (decimalParts.length === 0) {
+    return hours;
+  }
+
+  return `${hours}.${decimalParts.join("")}`;
 };
 
 /**


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

This PR adds support for floating-point values in the `DurationInput` component. For example, entering `1.5` will automatically be converted to `01:30`.


## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->


https://github.com/user-attachments/assets/0b126805-f63b-42c4-ab76-1e75e358a481


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1804
