### PR TITLE
Fix overlap issue for long item names in Combobox

### DIFF
--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -45,6 +45,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
   onChange,
   className,
   inputClassName,
+  popupClassName,
 }) => {
   const [open, setOpen] = useState(false);
   const [internalQuery, setInternalQuery] = useState("");
@@ -221,7 +222,8 @@ export const Combobox: React.FC<ComboboxProps> = ({
             >
               <BaseCombobox.Popup
                 className={cn(
-                  "min-w-[160px] w-(--anchor-width) rounded-lg border border-surface-gray-2 bg-surface-modal px-1.5 py-1.5 shadow-xl animate-fade-in"
+                  "min-w-[160px] w-(--anchor-width) rounded-lg border border-surface-gray-2 bg-surface-modal px-1.5 py-1.5 shadow-xl animate-fade-in",
+                  popupClassName
                 )}
                 aria-label="Options"
               >
@@ -265,7 +267,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
                                   </span>
                                 </div>
                               ) : (
-                                <span className="flex-1">
+                                <span className="flex-1 w-full truncate">
                                   {getLabel(option)}
                                 </span>
                               )}
@@ -305,7 +307,9 @@ export const Combobox: React.FC<ComboboxProps> = ({
                                 </span>
                               </div>
                             ) : (
-                              <span className="flex-1">{getLabel(opt)}</span>
+                              <span className="flex-1 w-full truncate">
+                                {getLabel(opt)}
+                              </span>
                             )}
                             <BaseCombobox.ItemIndicator className="absolute right-2 inline-flex items-center justify-center text-ink-gray-5">
                               <Check className="size-4" />

--- a/packages/frappe-ui-react/src/components/combobox/types.ts
+++ b/packages/frappe-ui-react/src/components/combobox/types.ts
@@ -27,4 +27,5 @@ export interface ComboboxProps {
   ) => void;
   className?: string;
   inputClassName?: string;
+  popupClassName?: string;
 }


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

Fixes the tick icon and the long item name overlap issue in combobox.

Other:
* Also adds a `popupClassName` prop to allow customizing the width of the combobox popover.

## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->
Before:

<img width="410" height="129" alt="Screenshot 2026-07-13 at 6 27 31 PM" src="https://github.com/user-attachments/assets/4661e27e-bdc2-4b09-903d-2e49f3bd922e" />

After:
<img width="410" height="129" alt="Screenshot 2026-07-13 at 6 27 56 PM" src="https://github.com/user-attachments/assets/30081dfb-9fb9-46c7-bf3d-b73826e85af2" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1819
