### PR TITLE
feat: add min/max/step support in text input

### DIFF
--- a/packages/frappe-ui-react/src/components/textInput/textInput.stories.tsx
+++ b/packages/frappe-ui-react/src/components/textInput/textInput.stories.tsx
@@ -85,7 +85,7 @@ export default {
 } as Meta<typeof TextInput>;
 
 const Template: StoryObj<TextInputProps> = {
-  render: (args) => {
+  render: (args: TextInputProps) => {
     const [value, setValue] = useState(args.value || "");
 
     return (

--- a/packages/frappe-ui-react/src/components/textInput/types.ts
+++ b/packages/frappe-ui-react/src/components/textInput/types.ts
@@ -1,8 +1,13 @@
 import type { KeyboardEventHandler, ReactNode } from "react";
 import type { TextInputTypes } from "../../common/types";
 
-export interface TextInputProps {
-  type?: TextInputTypes;
+// Only these input types honor min/max/step per the HTML spec.
+type SteppableInputTypes = Extract<
+  TextInputTypes,
+  "number" | "range" | "date" | "month" | "week" | "time" | "datetime-local"
+>;
+
+export interface TextInputBaseProps {
   size?: "sm" | "md" | "lg" | "xl";
   variant?: "subtle" | "outline" | "ghost";
   placeholder?: string;
@@ -22,3 +27,14 @@ export interface TextInputProps {
   inputClassName?: string;
   style?: Record<string, string | number | boolean>;
 }
+
+type TextInputTypeProps =
+  | {
+      type: SteppableInputTypes;
+      min?: string | number;
+      max?: string | number;
+      step?: string | number;
+    }
+  | { type?: Exclude<TextInputTypes, SteppableInputTypes> };
+
+export type TextInputProps = TextInputBaseProps & TextInputTypeProps;


### PR DESCRIPTION
## Description
Adds min, max, and step props to TextInput, restricted at the type level to the input types that actually honor them (number, range, date, month, week, time, datetime-local) - passing them with any other type (e.g. text, email) is now a compile-time error instead of silently doing nothing.

## Relevant Technical Choices
- types.ts: split TextInputProps into a discriminated union on type; exported TextInputBaseProps since it's now part of the public type.

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).