### PR TITLE
feat: add displayLabel to link filter value props

### DIFF
--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -124,6 +124,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
       field: value,
       operator: firstOperator,
       value: null,
+      displayLabel: undefined,
       fieldCategory: newField?.fieldCategory,
     });
   };
@@ -137,13 +138,18 @@ export const FilterRow: React.FC<FilterRowProps> = ({
       operator: value,
       // Clear value if new operator hides it
       value: newOperator?.hideValue ? null : filter.value,
+      displayLabel: newOperator?.hideValue ? undefined : filter.displayLabel,
     });
   };
 
-  const handleValueChange = (value: string | string[] | null) => {
+  const handleValueChange = (
+    value: string | string[] | null,
+    displayLabel?: string | null
+  ) => {
     onChange({
       ...filter,
       value,
+      displayLabel: displayLabel ?? undefined,
     });
   };
 
@@ -235,7 +241,8 @@ export const FilterRow: React.FC<FilterRowProps> = ({
           const linkValueProps: FilterLinkValueRenderProps = {
             field: selectedField,
             value: typeof filter.value === "string" ? filter.value : null,
-            onChange: (v) => handleValueChange(v),
+            displayLabel: filter.displayLabel,
+            onChange: handleValueChange,
             disabled: !filter.operator,
           };
           return renderLinkValue(linkValueProps);

--- a/packages/frappe-ui-react/src/components/filter/types.ts
+++ b/packages/frappe-ui-react/src/components/filter/types.ts
@@ -90,8 +90,10 @@ export interface FilterLinkValueRenderProps {
   field: FilterField;
   /** Current value (the linked document name). */
   value: string | null;
+  /** Display label for the current value. */
+  displayLabel?: string;
   /** Callback to update the value. */
-  onChange: (value: string | null) => void;
+  onChange: (value: string | null, displayLabel?: string | null) => void;
   /** Whether the value input should be disabled. */
   disabled?: boolean;
 }
@@ -108,6 +110,8 @@ export interface FilterCondition {
   operator: string;
   /** The value(s) to filter by */
   value?: string | string[] | number | null;
+  /** Human-friendly label for link values. */
+  displayLabel?: string;
 }
 
 /** Props for Filter component */


### PR DESCRIPTION
## Description

Adds displayLabel to link filter render props so the consumer can persist the human-readable name alongside the stored value. Prevents raw IDs from showing after popover close/reopen.

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Part of: https://github.com/rtCamp/next-pms/issues/1832

Required for: https://github.com/rtCamp/next-pms/pull/1847