### PR TITLE
Fix: Extra line breaks on copy from TextEditor components

### DIFF
--- a/packages/frappe-ui-react/src/components/textEditor/staticTextEditor.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/staticTextEditor.tsx
@@ -1,10 +1,11 @@
 /**
  * External dependencies.
  */
-import { generateJSON } from "@tiptap/react";
+import { generateJSON, getSchema } from "@tiptap/react";
+import { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { renderToReactElement } from "@tiptap/static-renderer/pm/react";
 import DOMPurify from "dompurify";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 /**
  * Internal dependencies.
@@ -33,6 +34,34 @@ const StaticTextEditor = ({
     [extensions, starterkitOptions, placeholder]
   );
 
+  /**
+   * Handle copy event to copy both plain text and HTML content.
+   *
+   * Remove extra line breaks and spaces from the plain text copied content.
+   */
+  const handleCopy = useCallback(
+    (event: React.ClipboardEvent<HTMLDivElement>) => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) return;
+
+      const container = document.createElement("div");
+      container.appendChild(selection.getRangeAt(0).cloneContents());
+      const html = container.innerHTML;
+      const doc = ProseMirrorNode.fromJSON(
+        getSchema(editorExtensions),
+        generateJSON(html, editorExtensions)
+      );
+
+      event.clipboardData.setData(
+        "text/plain",
+        doc.textBetween(0, doc.content.size, "\n")
+      );
+      event.clipboardData.setData("text/html", html);
+      event.preventDefault();
+    },
+    [editorExtensions]
+  );
+
   const staticContent = useMemo(
     () =>
       renderToReactElement({
@@ -51,7 +80,9 @@ const StaticTextEditor = ({
   );
 
   return (
-    <div className={cn(DEFAULT_EDITOR_CLASS, editorClass)}>{staticContent}</div>
+    <div className={cn(DEFAULT_EDITOR_CLASS, editorClass)} onCopy={handleCopy}>
+      {staticContent}
+    </div>
   );
 };
 

--- a/packages/frappe-ui-react/src/components/textEditor/textEditor.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/textEditor.tsx
@@ -60,6 +60,8 @@ const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
           attributes: {
             class: cn(DEFAULT_EDITOR_CLASS, editorClass),
           },
+          clipboardTextSerializer: (slice) =>
+            slice.content.textBetween(0, slice.content.size, "\n"),
         },
         extensions: editorExtensions,
         onUpdate: ({ editor }) => {


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

<!-- What do we want to achieve with this PR? -->
This PR removes the extra line breaks that were added to the copied content when copying from `TextEditor` components.


## Relevant Technical Choices

<!-- Please describe your changes. -->
* For the `TextEditor` component, TipTap's text serializer was adding extra line breaks for every block node, resulting in unnecessary blank lines when copying plain text. This happened because TipTap's serializer replaced the default ProseMirror serializer. This PR restores the ProseMirror behavior, which removes unnecessary line breaks while preserving the line breaks intentionally added by the user.
* For the `StaticTextEditor` component, custom handling is required because list items are rendered with markup such as `<li><p>...</p></li>`. The additional `<p>` element causes extra blank lines when lists are copied as plain text. To resolve this, the default copy behavior is prevented and the plain text is generated manually, removing the unnecessary blank lines. This approach keeps the copy behavior consistent with the `TextEditor` component.
* Rich text copy behavior remains unchanged for both components. Users can still copy and paste content into applications that support rich text formatting without any changes. This fix only affects plain text copying in applications that do not support rich text, such as Notes or other plain text editors.


## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->
Before:

https://github.com/user-attachments/assets/9a4e78aa-7157-4844-b8e0-c3206db6447a



After:


https://github.com/user-attachments/assets/567c5141-79d9-410f-8b4b-71c5f2c3c859



---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1668
