### PR TITLE
fix: loading icon

### DIFF
--- a/packages/frappe-ui-react/src/icons/line/loading-alt.svg
+++ b/packages/frappe-ui-react/src/icons/line/loading-alt.svg
@@ -1,11 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g clip-path="url(#a)" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1">
+  <g stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1">
     <path
       d="M8 1.333V4m2.8 1.2 1.933-1.933M12 8h2.667M10.8 10.8l1.933 1.933M8 12v2.667m-4.733-1.934L5.2 10.8M1.333 8H4m-.733-4.733L5.2 5.2" />
   </g>
-  <defs>
-    <clipPath id="a">
-      <path fill="#fff" d="M0 0h16v16H0z" />
-    </clipPath>
-  </defs>
 </svg>


### PR DESCRIPTION
## Description
- Fix loading icon clipping issue

## Relevant Technical Choices
- Removes the clip path from loading alt icon to prevent clipping.

## Screenshot/Screencast
Before:
<img width="626" height="238" alt="image" src="https://github.com/user-attachments/assets/56b6b329-cf2e-4fb0-bf44-01e0502613eb" />

After:
<img width="634" height="242" alt="image" src="https://github.com/user-attachments/assets/a74f7b8b-0766-478a-9c09-8f7a010194a8" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).