### PR TITLE
feature: allow renderMenuItem prop in dropdown

### DIFF
--- a/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
@@ -2,21 +2,40 @@
  * External dependencies.
  */
 import React, { useMemo } from "react";
+import { useRender } from "@base-ui/react/use-render";
 
 /**
  * Internal dependencies.
  */
 import useWindowSize from "../hooks/useWindowSize";
-import {
-  Dropdown,
-  type DropdownOption,
-  type DropdownOptions,
-} from "../dropdown";
+import { Dropdown, type DropdownOption, type DropdownOptions } from "../dropdown";
 import { Button } from "../button";
-import type { BreadcrumbsProps, BreadcrumbItem } from "./types";
+import type { BreadcrumbsProps, BreadcrumbItem, BreadcrumbDropdownState } from "./types";
 import { cn } from "../../utils";
 import { crumbVariants, separatorVariants } from "./variants";
 import { ThreeDotsIcon } from "./threeDotsIcon";
+
+const dropdownStateAttributesMapping = {
+  item: () => null,
+};
+
+const BreadcrumbDropdown = ({
+  item,
+  render,
+  children,
+}: {
+  item: BreadcrumbItem;
+  render?: BreadcrumbsProps["renderDropdown"];
+  children: React.ReactNode;
+}) => {
+  const state: BreadcrumbDropdownState = useMemo(() => ({ item }), [item]);
+  return useRender({
+    render: render ?? <Dropdown {...(item.dropdown ?? { options: [] })} />,
+    state,
+    stateAttributesMapping: dropdownStateAttributesMapping,
+    props: { children },
+  });
+};
 
 const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   items,
@@ -29,6 +48,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   separatorClassName,
   renderPrefix,
   renderSuffix,
+  renderDropdown,
 }) => {
   const { width } = useWindowSize();
 
@@ -80,18 +100,11 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
         </div>
       )}
 
-      <div
-        className={cn(
-          "flex min-w-0 items-center text-ellipsis whitespace-nowrap",
-          className
-        )}
-      >
+      <div className={cn("flex min-w-0 items-center text-ellipsis whitespace-nowrap", className)}>
         {crumbs.map((item, i) => {
           const isLast = i === crumbs.length - 1;
 
-          const handleClick = (
-            e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>
-          ) => {
+          const handleClick = (e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
             e.preventDefault();
             if (item.onClick && item?.interactive !== false) {
               item.onClick();
@@ -106,8 +119,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
               className={cn(
                 crumbVariants({
                   size,
-                  highlightItem:
-                    (isLast && highlightLastItem) || highlightAllItems,
+                  highlightItem: (isLast && highlightLastItem) || highlightAllItems,
                   interactive: item?.interactive !== false,
                 }),
                 crumbClassName
@@ -130,7 +142,9 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
           return (
             <React.Fragment key={item.id || item.label}>
               {item.dropdown ? (
-                <Dropdown {...item.dropdown}>{crumbContent}</Dropdown>
+                <BreadcrumbDropdown item={item} render={renderDropdown}>
+                  {crumbContent}
+                </BreadcrumbDropdown>
               ) : (
                 crumbContent
               )}

--- a/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
@@ -19,18 +19,11 @@ const dropdownStateAttributesMapping = {
   item: () => null,
 };
 
-const BreadcrumbDropdown = ({
-  item,
-  render,
-  children,
-}: {
-  item: BreadcrumbItem;
-  render?: BreadcrumbsProps["renderDropdown"];
-  children: React.ReactNode;
-}) => {
+const BreadcrumbDropdown = ({ item, children }: { item: BreadcrumbItem; children: React.ReactNode }) => {
   const state: BreadcrumbDropdownState = useMemo(() => ({ item }), [item]);
+  const { renderDropdown, ...dropdownProps } = item.dropdown ?? { options: [] };
   return useRender({
-    render: render ?? <Dropdown {...(item.dropdown ?? { options: [] })} />,
+    render: renderDropdown ?? <Dropdown {...dropdownProps} />,
     state,
     stateAttributesMapping: dropdownStateAttributesMapping,
     props: { children },
@@ -48,7 +41,6 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   separatorClassName,
   renderPrefix,
   renderSuffix,
-  renderDropdown,
 }) => {
   const { width } = useWindowSize();
 
@@ -141,13 +133,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
 
           return (
             <React.Fragment key={item.id || item.label}>
-              {item.dropdown ? (
-                <BreadcrumbDropdown item={item} render={renderDropdown}>
-                  {crumbContent}
-                </BreadcrumbDropdown>
-              ) : (
-                crumbContent
-              )}
+              {item.dropdown ? <BreadcrumbDropdown item={item}>{crumbContent}</BreadcrumbDropdown> : crumbContent}
               {!isLast && (
                 <span
                   className={cn(

--- a/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/breadcrumbs.tsx
@@ -109,6 +109,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
               onClick={handleClick}
               disabled={item?.interactive === false}
               className={cn(
+                "min-w-0",
                 crumbVariants({
                   size,
                   highlightItem: (isLast && highlightLastItem) || highlightAllItems,
@@ -122,7 +123,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
               ) : item?.prefixIcon ? (
                 <span className="mr-1">{item.prefixIcon}</span>
               ) : null}
-              <span>{item.label}</span>
+              <span className="truncate">{item.label}</span>
               {renderSuffix ? (
                 renderSuffix(item)
               ) : item?.suffixIcon ? (

--- a/packages/frappe-ui-react/src/components/breadcrumbs/types.ts
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/types.ts
@@ -8,9 +8,25 @@ export interface BreadcrumbItem {
   onClick?: () => void;
   prefixIcon?: ReactNode;
   suffixIcon?: ReactNode;
-  dropdown?: DropdownProps;
+  dropdown?: BreadcrumbDropdownProps;
   interactive?: boolean;
 }
+
+export type BreadcrumbDropdownState = {
+  item: BreadcrumbItem;
+};
+
+export type BreadcrumbRenderDropdown =
+  useRender.RenderProp<BreadcrumbDropdownState>;
+
+export type BreadcrumbDropdownProps = DropdownProps & {
+  /**
+   * Replace the default `<Dropdown>` wrapper of this crumb. Accepts a React
+   * element or a render function that receives the merged props (`children`
+   * is the crumb trigger) and the crumb's `state`.
+   */
+  renderDropdown?: BreadcrumbRenderDropdown;
+};
 
 export interface BreadcrumbsProps {
   items: BreadcrumbItem[];
@@ -23,14 +39,4 @@ export interface BreadcrumbsProps {
   separatorClassName?: string;
   renderPrefix?: (item: BreadcrumbItem) => ReactNode;
   renderSuffix?: (item: BreadcrumbItem) => ReactNode;
-  /**
-   * Replace the default `<Dropdown>` wrapper of a crumb that has `dropdown`
-   * set. Accepts a React element or a render function that receives the
-   * merged props (`children` is the crumb trigger) and the crumb's `state`.
-   */
-  renderDropdown?: useRender.RenderProp<BreadcrumbDropdownState>;
 }
-
-export type BreadcrumbDropdownState = {
-  item: BreadcrumbItem;
-};

--- a/packages/frappe-ui-react/src/components/breadcrumbs/types.ts
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { useRender } from "@base-ui/react/use-render";
 import type { DropdownProps } from "../dropdown";
 
 export interface BreadcrumbItem {
@@ -22,4 +23,14 @@ export interface BreadcrumbsProps {
   separatorClassName?: string;
   renderPrefix?: (item: BreadcrumbItem) => ReactNode;
   renderSuffix?: (item: BreadcrumbItem) => ReactNode;
+  /**
+   * Replace the default `<Dropdown>` wrapper of a crumb that has `dropdown`
+   * set. Accepts a React element or a render function that receives the
+   * merged props (`children` is the crumb trigger) and the crumb's `state`.
+   */
+  renderDropdown?: useRender.RenderProp<BreadcrumbDropdownState>;
 }
+
+export type BreadcrumbDropdownState = {
+  item: BreadcrumbItem;
+};

--- a/packages/frappe-ui-react/src/components/dropdown/dropdown.stories.tsx
+++ b/packages/frappe-ui-react/src/components/dropdown/dropdown.stories.tsx
@@ -4,6 +4,7 @@ import { action } from "storybook/actions";
 import { useState } from "react";
 import Dropdown from "./dropdown";
 import { Button } from "../button";
+import { Calendar, Delete, DotHorizontal, Duplicate, Edit, Kanban, List } from "../../icons";
 import type { DropdownOptions } from "./types";
 
 export default {
@@ -12,17 +13,19 @@ export default {
   argTypes: {
     options: {
       control: "object",
-      description:
-        "An array of dropdown options, which can be individual items or groups.",
+      description: "An array of dropdown options, which can be individual items or groups.",
     },
     placement: {
       control: { type: "select", options: ["left", "right", "center"] },
       description: "Placement of the dropdown content relative to the trigger.",
     },
+    side: {
+      control: { type: "select", options: ["top", "bottom", "left", "right"] },
+      description: "Which side of the trigger the dropdown opens on.",
+    },
     button: {
       control: "object",
-      description:
-        "Props for the default button trigger if no children are provided.",
+      description: "Props for the default button trigger if no children are provided.",
     },
     children: {
       control: "text",
@@ -38,18 +41,20 @@ export default {
     },
     renderItems: {
       control: false,
+      description: "Function to render custom dropdown items, receives options as argument.",
+    },
+    renderMenuItem: {
+      control: false,
       description:
-        "Function to render custom dropdown items, receives options as argument.",
+        "Overrides the rendering of plain menu items. Receives the default item props (className, children with icon + label) and `{ item }` as state.",
     },
     selectedKey: {
       control: "text",
-      description:
-        "Key of the currently selected dropdown item, used for highlighting.",
+      description: "Key of the currently selected dropdown item, used for highlighting.",
     },
     selectedGroupKey: {
       control: "text",
-      description:
-        "Key of the currently selected dropdown group, used for highlighting.",
+      description: "Key of the currently selected dropdown group, used for highlighting.",
     },
   },
   parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
@@ -334,5 +339,94 @@ export const WithNestedSubmenus: StoryObj<typeof Dropdown> = {
   args: {
     options: groupedActions,
     button: { label: "Nested Submenus" },
+  },
+};
+
+export const OpensToTheRight: StoryObj<typeof Dropdown> = {
+  ...DropdownTemplate,
+  args: {
+    options: actions,
+    side: "right",
+    button: { label: "Opens Right" },
+  },
+};
+
+const views: DropdownOptions = [
+  {
+    label: "List",
+    key: "list",
+    icon: <List className="mr-2 h-4 w-4" />,
+    onClick: () => action("List clicked")(),
+  },
+  {
+    label: "Kanban",
+    key: "kanban",
+    icon: <Kanban className="mr-2 h-4 w-4" />,
+    onClick: () => action("Kanban clicked")(),
+  },
+  {
+    label: "Calendar",
+    key: "calendar",
+    icon: <Calendar className="mr-2 h-4 w-4" />,
+    onClick: () => action("Calendar clicked")(),
+  },
+];
+
+const viewActions: DropdownOptions = [
+  {
+    group: "",
+    key: "view-actions",
+    items: [
+      {
+        label: "Duplicate",
+        icon: <Duplicate className="mr-2 h-4 w-4" />,
+        onClick: () => action("Duplicate clicked")(),
+      },
+      {
+        label: "Edit",
+        icon: <Edit className="mr-2 h-4 w-4" />,
+        onClick: () => action("Edit clicked")(),
+      },
+    ],
+  },
+  {
+    group: "",
+    key: "view-danger-actions",
+    items: [
+      {
+        label: "Delete",
+        icon: <Delete className="mr-2 h-4 w-4" />,
+        theme: "red",
+        onClick: () => action("Delete clicked")(),
+      },
+    ],
+  },
+];
+
+export const WithRenderMenuItem: StoryObj<typeof Dropdown> = {
+  ...DropdownTemplate,
+  args: {
+    options: views,
+    selectedKey: "list",
+    button: { label: "Views" },
+    renderMenuItem: (props, state) =>
+      state.item.key === "list" ? (
+        <button {...props} />
+      ) : (
+        <div {...props}>
+          {props.children}
+          <div className="ml-auto" onClick={(event) => event.stopPropagation()}>
+            <Dropdown options={viewActions} side="right">
+              <button
+                type="button"
+                aria-label={`Actions for ${state.item.label}`}
+                className="flex rounded p-0.5 text-ink-gray-6 hover:bg-surface-gray-4"
+              >
+                <DotHorizontal className="h-4 w-4" />
+              </button>
+            </Dropdown>
+          </div>
+        </div>
+      ),
   },
 };

--- a/packages/frappe-ui-react/src/components/dropdown/dropdown.tsx
+++ b/packages/frappe-ui-react/src/components/dropdown/dropdown.tsx
@@ -3,6 +3,7 @@
  */
 import React, { useMemo, useCallback } from "react";
 import { Menu } from "@base-ui/react/menu";
+import { useRender } from "@base-ui/react/use-render";
 
 /**
  * Internal dependencies.
@@ -14,6 +15,8 @@ import type {
   DropdownOption,
   DropdownGroupOption,
   DropdownOptions,
+  DropdownItemState,
+  DropdownRenderMenuItem,
 } from "./types";
 import FeatherIcon, { type FeatherIconProps } from "../featherIcon";
 import { cn } from "../../utils";
@@ -26,16 +29,40 @@ const cssClasses = {
   itemLabel: "whitespace-nowrap",
   itemIcon: "mr-2 h-4 w-4 flex-shrink-0",
   chevronIcon: "ml-auto h-4 w-4 flex-shrink-0",
-  itemButton:
-    "group flex h-7 w-full items-center rounded px-2 text-base focus:outline-none",
-  submenuTrigger:
-    "group flex h-7 w-full items-center rounded px-2 text-base text-ink-gray-6 focus:outline-none",
+  itemButton: "group flex h-7 w-full items-center rounded px-2 text-base focus:outline-none",
+  submenuTrigger: "group flex h-7 w-full items-center rounded px-2 text-base text-ink-gray-6 focus:outline-none",
   dropdownPositioner: "z-100 py-1",
+};
+
+const itemStateAttributesMapping = {
+  item: () => null,
+};
+
+const DropdownItem = ({
+  item,
+  render,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLElement> & {
+  item: DropdownOption;
+  render?: DropdownRenderMenuItem;
+  ref?: React.Ref<Element>;
+}) => {
+  const state: DropdownItemState = useMemo(() => ({ item }), [item]);
+  return useRender({
+    render: render as useRender.RenderProp<DropdownItemState>,
+    defaultTagName: "button",
+    ref,
+    state,
+    stateAttributesMapping: itemStateAttributesMapping,
+    props,
+  });
 };
 
 const Dropdown: React.FC<DropdownProps> = ({
   options = [],
   placement = "left",
+  side = "bottom",
   dropdownClassName = "",
   groupClassName = "",
   itemClassName = "",
@@ -43,6 +70,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   selectedGroupKey,
   button,
   renderItems,
+  renderMenuItem,
   children,
   ...attrs
 }) => {
@@ -54,11 +82,9 @@ const Dropdown: React.FC<DropdownProps> = ({
     }
   }, []);
 
-  const getIconColor = (item: DropdownOption) =>
-    item.theme === "red" ? "text-ink-red-3" : "text-ink-gray-6";
+  const getIconColor = (item: DropdownOption) => (item.theme === "red" ? "text-ink-red-3" : "text-ink-gray-6");
 
-  const getTextColor = (item: DropdownOption) =>
-    item.theme === "red" ? "text-ink-red-3" : "text-ink-gray-7";
+  const getTextColor = (item: DropdownOption) => (item.theme === "red" ? "text-ink-red-3" : "text-ink-gray-7");
 
   const getBackgroundColor = (item: DropdownOption) =>
     item.theme === "red"
@@ -68,9 +94,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   const getSubmenuBackgroundColor = (item: DropdownOption) =>
     cn(
       getBackgroundColor(item),
-      item.theme === "red"
-        ? " data-[state=open]:bg-surface-red-3"
-        : " data-[state=open]:bg-surface-gray-4"
+      item.theme === "red" ? " data-[state=open]:bg-surface-red-3" : " data-[state=open]:bg-surface-gray-4"
     );
 
   const normalizeDropdownItem = useCallback(
@@ -98,10 +122,7 @@ const Dropdown: React.FC<DropdownProps> = ({
         .filter(Boolean)
         .filter(
           (option) =>
-            !("group" in option) &&
-            ("condition" in option
-              ? ((option as DropdownOption).condition?.() ?? true)
-              : true)
+            !("group" in option) && ("condition" in option ? ((option as DropdownOption).condition?.() ?? true) : true)
         )
         .map((option) => normalizeDropdownItem(option as DropdownOption));
     },
@@ -159,12 +180,9 @@ const Dropdown: React.FC<DropdownProps> = ({
     [filterAndNormalizeOptions]
   );
 
-  const groups = useMemo(
-    () => processOptionsIntoGroups(options),
-    [options, processOptionsIntoGroups]
-  );
+  const groups = useMemo(() => processOptionsIntoGroups(options), [options, processOptionsIntoGroups]);
 
-  const contentSide = "bottom";
+  const contentSide = side;
   const contentAlign = useMemo(() => {
     if (placement === "left") return "start";
     if (placement === "right") return "end";
@@ -172,18 +190,13 @@ const Dropdown: React.FC<DropdownProps> = ({
     return "start";
   }, [placement]);
 
-  const renderDropdownItem = (
-    item: DropdownOption & { groupKey?: string | number }
-  ) => {
+  const renderDropdownItem = (item: DropdownOption & { groupKey?: string | number }) => {
     if (item.component) {
       const CustomComponent = item.component;
       return <CustomComponent active={false} />;
     } else if (item.switch) {
       return (
-        <div
-          className={cn(cssClasses.itemButton, getTextColor(item))}
-          onClick={(e) => e.preventDefault()}
-        >
+        <div className={cn(cssClasses.itemButton, getTextColor(item))} onClick={(e) => e.preventDefault()}>
           {item.icon &&
             (typeof item.icon === "string" ? (
               <FeatherIcon
@@ -220,21 +233,11 @@ const Dropdown: React.FC<DropdownProps> = ({
                   ) : null)
                 }
                 iconRight={() => (
-                  <FeatherIcon
-                    name="chevron-right"
-                    className={cssClasses.chevronIcon}
-                    aria-hidden="true"
-                  />
+                  <FeatherIcon name="chevron-right" className={cssClasses.chevronIcon} aria-hidden="true" />
                 )}
-                className={cn(
-                  cssClasses.submenuTrigger,
-                  getSubmenuBackgroundColor(item)
-                )}
+                className={cn(cssClasses.submenuTrigger, getSubmenuBackgroundColor(item))}
               >
-                <span
-                  className={cssClasses.itemLabel}
-                  data-testid="dropdown-submenu-trigger"
-                >
+                <span className={cssClasses.itemLabel} data-testid="dropdown-submenu-trigger">
                   {item.label}
                 </span>
               </Button>
@@ -242,31 +245,19 @@ const Dropdown: React.FC<DropdownProps> = ({
             nativeButton={true}
           />
           <Menu.Portal>
-            <Menu.Positioner
-              sideOffset={4}
-              className={cssClasses.dropdownPositioner}
-            >
+            <Menu.Positioner sideOffset={4} className={cssClasses.dropdownPositioner}>
               <Menu.Popup className={cssClasses.dropdownContent}>
                 {processOptionsIntoGroups(item.submenu).map((submenuGroup) => (
-                  <Menu.Group
-                    key={submenuGroup.key}
-                    className={cssClasses.groupContainer}
-                  >
+                  <Menu.Group key={submenuGroup.key} className={cssClasses.groupContainer}>
                     {submenuGroup.group && !submenuGroup.hideLabel && (
-                      <Menu.GroupLabel className={cssClasses.groupLabel}>
-                        {submenuGroup.group}
-                      </Menu.GroupLabel>
+                      <Menu.GroupLabel className={cssClasses.groupLabel}>{submenuGroup.group}</Menu.GroupLabel>
                     )}
                     {submenuGroup.items.map((subItem) => (
                       <Menu.Item
                         key={subItem.label}
                         onClick={() => subItem.onClick?.()}
                         render={renderDropdownItem(subItem)}
-                        nativeButton={
-                          !subItem.switch &&
-                          !subItem.submenu &&
-                          !subItem.component
-                        }
+                        nativeButton={!subItem.switch && !subItem.submenu && !subItem.component && !renderMenuItem}
                       />
                     ))}
                   </Menu.Group>
@@ -278,7 +269,9 @@ const Dropdown: React.FC<DropdownProps> = ({
       );
     } else {
       return (
-        <button
+        <DropdownItem
+          item={item}
+          render={renderMenuItem}
           className={cn(
             cssClasses.itemButton,
             getTextColor(item),
@@ -294,15 +287,12 @@ const Dropdown: React.FC<DropdownProps> = ({
         >
           {item.icon &&
             (typeof item.icon === "string" ? (
-              <FeatherIcon
-                name={item.icon as FeatherIconProps["name"]}
-                className={cssClasses.itemIcon}
-              />
+              <FeatherIcon name={item.icon as FeatherIconProps["name"]} className={cssClasses.itemIcon} />
             ) : React.isValidElement(item.icon) ? (
               item.icon
             ) : null)}
           <span className={cssClasses.itemLabel}>{item.label}</span>
-        </button>
+        </DropdownItem>
       );
     }
   };
@@ -314,11 +304,7 @@ const Dropdown: React.FC<DropdownProps> = ({
           children ? (
             React.cloneElement(children as React.ReactElement, { ...attrs })
           ) : (
-            <Button
-              {...(button as ButtonProps)}
-              {...attrs}
-              data-testid="dropdown-trigger"
-            >
+            <Button {...(button as ButtonProps)} {...attrs} data-testid="dropdown-trigger">
               {button?.label || "Options"}
             </Button>
           )
@@ -346,14 +332,9 @@ const Dropdown: React.FC<DropdownProps> = ({
             {renderItems
               ? renderItems(options)
               : groups.map((group) => (
-                  <Menu.Group
-                    key={group.key}
-                    className={cn(cssClasses.groupContainer, groupClassName)}
-                  >
+                  <Menu.Group key={group.key} className={cn(cssClasses.groupContainer, groupClassName)}>
                     {group.group && !group.hideLabel && (
-                      <Menu.GroupLabel className={cssClasses.groupLabel}>
-                        {group.group}
-                      </Menu.GroupLabel>
+                      <Menu.GroupLabel className={cssClasses.groupLabel}>{group.group}</Menu.GroupLabel>
                     )}
                     {group.items.map((item) => (
                       <div data-testid="dropdown-item" key={item.label}>
@@ -364,9 +345,7 @@ const Dropdown: React.FC<DropdownProps> = ({
                             ...item,
                             groupKey: group.groupKey,
                           })}
-                          nativeButton={
-                            !item.switch && !item.submenu && !item.component
-                          }
+                          nativeButton={!item.switch && !item.submenu && !item.component && !renderMenuItem}
                         />
                       </div>
                     ))}

--- a/packages/frappe-ui-react/src/components/dropdown/dropdown.tsx
+++ b/packages/frappe-ui-react/src/components/dropdown/dropdown.tsx
@@ -26,7 +26,7 @@ const cssClasses = {
     "min-w-40 divide-y divide-outline-gray-modals rounded-lg bg-surface-modal shadow-2xl ring-black focus:outline-none dropdown-content border border-outline-gray-1",
   groupContainer: "p-1.5",
   groupLabel: "flex h-7 items-center px-2 text-sm font-medium text-ink-gray-7",
-  itemLabel: "whitespace-nowrap",
+  itemLabel: "truncate",
   itemIcon: "mr-2 h-4 w-4 flex-shrink-0",
   chevronIcon: "ml-auto h-4 w-4 flex-shrink-0",
   itemButton: "group flex h-7 w-full items-center rounded px-2 text-base focus:outline-none",

--- a/packages/frappe-ui-react/src/components/dropdown/types.ts
+++ b/packages/frappe-ui-react/src/components/dropdown/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, ComponentType } from "react";
+import type { ReactElement, ReactNode, ComponentType } from "react";
 import type { ButtonProps } from "../button";
 import type { ButtonTheme } from "../button";
 
@@ -28,9 +28,33 @@ export interface DropdownGroupOption {
 
 export type DropdownOptions = (DropdownOption | DropdownGroupOption)[];
 
+export type DropdownItemState = {
+  item: DropdownOption;
+};
+
+/**
+ * Default props of a menu item, forwarded to `renderMenuItem`. Kept
+ * structural (no React.HTMLAttributes) so consumers with their own copy of
+ * @types/react can spread them onto JSX without type-identity conflicts.
+ */
+export type DropdownItemRenderProps = {
+  className?: string;
+  children?: ReactNode;
+  [key: string]: unknown;
+};
+
+export type DropdownRenderMenuItem =
+  | ReactElement
+  | ((
+      props: DropdownItemRenderProps,
+      state: DropdownItemState
+    ) => ReactElement);
+
 export interface DropdownProps {
   options: DropdownOptions;
   placement?: "left" | "right" | "center";
+  /** Which side of the trigger the dropdown opens on. */
+  side?: "top" | "bottom" | "left" | "right";
   dropdownClassName?: string;
   groupClassName?: string;
   itemClassName?: string;
@@ -41,4 +65,9 @@ export interface DropdownProps {
   };
   children?: ReactNode;
   renderItems?: (options: DropdownOptions) => ReactNode;
+  /**
+   * Overrides the rendering of plain menu items. Receives the default item
+   * props (className, children with icon + label) and `{ item }` as state.
+   */
+  renderMenuItem?: DropdownRenderMenuItem;
 }


### PR DESCRIPTION
## Description

- Modifies Dropdown to have renderMenuItem prop for custom rendering. Required case shown in image.
- Modifies Breadcrumbs to take a renderDropdown prop to render a custom drop down.

<img width="433" height="335" alt="image" src="https://github.com/user-attachments/assets/e2bd4b05-442b-4a21-a2b7-5cefc347ad56" />





## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

