### PR TITLE
refactor: date range picker to emit change event on single selection

### DIFF
--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.interactions.stories.tsx
@@ -78,6 +78,12 @@ export const KeyboardNavigation: Story = {
 
     await userEvent.keyboard("{Enter}");
 
+    // Selecting only the start date emits it with a pending, empty end date.
+    expect(args.onChange).toHaveBeenLastCalledWith([
+      expect.stringMatching(/.+/),
+      "",
+    ]);
+
     let secondFocusedDate: HTMLElement | null = null;
     for (let i = 0; i < 6; i++) {
       await userEvent.tab();

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -122,6 +122,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
       <Popover.Trigger
         disabled={disabled}
         nativeButton={false}
+        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
         render={
           children ? (
             <span>

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -16,9 +16,15 @@ function useDateRangePicker({
   value?: string[];
   onChange?: (v: string[]) => void;
 }) {
-  // Internal selection state
-  const [fromDate, setFromDate] = useState<string>(value?.[0] || "");
-  const [toDate, setToDate] = useState<string>(value?.[1] || "");
+  // Selection state, used only when the range is not driven by `value`.
+  const [internalFrom, setInternalFrom] = useState<string>(value?.[0] || "");
+  const [internalTo, setInternalTo] = useState<string>(value?.[1] || "");
+  // Whether the next date click extends the current range instead of starting a new one.
+  const [isExtendingRange, setIsExtendingRange] = useState(false);
+
+  const isControlled = Array.isArray(value);
+  const fromDate = isControlled ? (value?.[0] ?? "") : internalFrom;
+  const toDate = isControlled ? (value?.[1] ?? "") : internalTo;
 
   const {
     open,
@@ -45,37 +51,30 @@ function useDateRangePicker({
     onChange: () => {},
   });
 
+  function commitRange(from: string, to: string) {
+    setInternalFrom(from);
+    setInternalTo(to);
+    onChange?.([from, to]);
+  }
+
   function handleDateClick(date: Date): boolean {
     // Zero out time for date
     const d = new Date(date);
     d.setHours(0, 0, 0, 0);
     const v = getDateValue(d);
     syncCalendarToValue(v);
-    if (fromDate && toDate) {
-      setFromDate(v);
-      setToDate("");
-    } else if (fromDate && !toDate) {
-      setToDate(v);
-      swapDatesIfNecessary(fromDate, v);
-      onChange?.([fromDate, v]);
-      return true;
-    } else {
-      setFromDate(v);
-    }
-    return false;
-  }
 
-  function swapDatesIfNecessary(a: string, b: string) {
-    if (!a || !b) return;
-    const from = getDate(a);
-    from.setHours(0, 0, 0, 0);
-    const to = getDate(b);
-    to.setHours(0, 0, 0, 0);
-
-    if (from > to) {
-      setFromDate(getDateValue(to));
-      setToDate(getDateValue(from));
+    // Commit the start as a single-day range so the value never lags behind the calendar.
+    if (!isExtendingRange || !fromDate) {
+      setIsExtendingRange(true);
+      commitRange(v, v);
+      return false;
     }
+
+    const isReversed = fromDate > v;
+    setIsExtendingRange(false);
+    commitRange(isReversed ? v : fromDate, isReversed ? fromDate : v);
+    return true;
   }
 
   function handleToday() {
@@ -83,17 +82,15 @@ function useDateRangePicker({
     d.setHours(0, 0, 0, 0);
     const todayStr = getDateValue(d);
     syncCalendarToValue(todayStr);
-    setFromDate(todayStr);
-    setToDate(todayStr);
-    onChange?.([todayStr, todayStr]);
+    setIsExtendingRange(false);
+    commitRange(todayStr, todayStr);
   }
 
   function clearDates() {
     syncCalendarToValue("");
     resetCalendarToToday();
-    setFromDate("");
-    setToDate("");
-    onChange?.(["", ""]);
+    setIsExtendingRange(false);
+    commitRange("", "");
   }
 
   function selectDates() {
@@ -103,9 +100,8 @@ function useDateRangePicker({
 
   function applyRange(from: string, to: string) {
     syncCalendarToValue(from);
-    setFromDate(from);
-    setToDate(to);
-    onChange?.([from, to]);
+    setIsExtendingRange(false);
+    commitRange(from, to);
   }
 
   function isInRange(date: Date) {
@@ -117,9 +113,7 @@ function useDateRangePicker({
     open,
     setOpen,
     fromDate,
-    setFromDate,
     toDate,
-    setToDate,
     formattedMonth,
     datesAsWeeks,
     currentMonth,

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -1,142 +1,19 @@
-import { useState } from "react";
+/**
+ * External dependencies.
+ */
+import { useCallback } from "react";
 import { Popover } from "@base-ui/react/popover";
 
+/**
+ * Internal dependencies.
+ */
 import type { DateRangePickerProps } from "./types";
-import { useDatePicker } from "./useDatePicker";
+import { useDateRangePicker } from "./useDateRangePicker";
 import { getDate, getDateValue, parsePlacement } from "./utils";
 import { Button } from "../button";
 import { TextInput } from "../textInput";
 import FeatherIcon from "../featherIcon";
 import { cn } from "../../utils";
-
-function useDateRangePicker({
-  value,
-  onChange,
-}: {
-  value?: string[];
-  onChange?: (v: string[]) => void;
-}) {
-  // Selection state, used only when the range is not driven by `value`.
-  const [internalFrom, setInternalFrom] = useState<string>(value?.[0] || "");
-  const [internalTo, setInternalTo] = useState<string>(value?.[1] || "");
-  // Whether the next date click extends the current range instead of starting a new one.
-  const [isExtendingRange, setIsExtendingRange] = useState(false);
-
-  const isControlled = Array.isArray(value);
-  const fromDate = isControlled ? (value?.[0] ?? "") : internalFrom;
-  const toDate = isControlled ? (value?.[1] ?? "") : internalTo;
-
-  const {
-    open,
-    setOpen,
-    formattedMonth,
-    datesAsWeeks,
-    currentMonth,
-    currentYear,
-    view,
-    cycleView,
-    selectMonth,
-    selectYear,
-    yearRangeStart,
-    yearRange,
-    prev,
-    next,
-    resetView,
-    months,
-    today,
-    syncCalendarToValue,
-    resetCalendarToToday,
-  } = useDatePicker({
-    value: fromDate,
-    onChange: () => {},
-  });
-
-  function commitRange(from: string, to: string) {
-    setInternalFrom(from);
-    setInternalTo(to);
-    onChange?.([from, to]);
-  }
-
-  function handleDateClick(date: Date): boolean {
-    // Zero out time for date
-    const d = new Date(date);
-    d.setHours(0, 0, 0, 0);
-    const v = getDateValue(d);
-    syncCalendarToValue(v);
-
-    // Commit the start as a single-day range so the value never lags behind the calendar.
-    if (!isExtendingRange || !fromDate) {
-      setIsExtendingRange(true);
-      commitRange(v, v);
-      return false;
-    }
-
-    const isReversed = fromDate > v;
-    setIsExtendingRange(false);
-    commitRange(isReversed ? v : fromDate, isReversed ? fromDate : v);
-    return true;
-  }
-
-  function handleToday() {
-    const d = new Date(today);
-    d.setHours(0, 0, 0, 0);
-    const todayStr = getDateValue(d);
-    syncCalendarToValue(todayStr);
-    setIsExtendingRange(false);
-    commitRange(todayStr, todayStr);
-  }
-
-  function clearDates() {
-    syncCalendarToValue("");
-    resetCalendarToToday();
-    setIsExtendingRange(false);
-    commitRange("", "");
-  }
-
-  function selectDates() {
-    onChange?.([fromDate, toDate]);
-    setOpen(false);
-  }
-
-  function applyRange(from: string, to: string) {
-    syncCalendarToValue(from);
-    setIsExtendingRange(false);
-    commitRange(from, to);
-  }
-
-  function isInRange(date: Date) {
-    if (!fromDate || !toDate) return false;
-    return date >= getDate(fromDate) && date <= getDate(toDate);
-  }
-
-  return {
-    open,
-    setOpen,
-    fromDate,
-    toDate,
-    formattedMonth,
-    datesAsWeeks,
-    currentMonth,
-    currentYear,
-    view,
-    cycleView,
-    selectMonth,
-    selectYear,
-    yearRangeStart,
-    yearRange,
-    prev,
-    next,
-    resetView,
-    months,
-    today,
-    handleToday,
-    handleDateClick,
-    clearDates,
-    selectDates,
-    applyRange,
-    isInRange,
-  };
-}
 
 export const DateRangePicker: React.FC<DateRangePickerProps> = ({
   value,
@@ -179,12 +56,43 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
     onChange,
   });
 
-  const handleOpenChange = (isOpen: boolean) => {
-    setOpen(isOpen);
-    if (!isOpen) {
-      resetView();
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setOpen(isOpen);
+      if (!isOpen) {
+        resetView();
+      }
+    },
+    [resetView, setOpen]
+  );
+
+  const openPicker = useCallback(() => {
+    if (!disabled) {
+      setOpen(true);
     }
-  };
+  }, [disabled, setOpen]);
+
+  const closePicker = useCallback(() => setOpen(false), [setOpen]);
+
+  const togglePicker = useCallback(() => {
+    if (!disabled) {
+      setOpen((prevOpen) => !prevOpen);
+    }
+  }, [disabled, setOpen]);
+
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (disabled) {
+        return;
+      }
+
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        openPicker();
+      }
+    },
+    [disabled, openPicker]
+  );
 
   const { side, align } = parsePlacement(placement);
 
@@ -195,41 +103,6 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
     : from && to
       ? `${from} to ${to}`
       : from || "";
-  const openPicker = () => {
-    if (!disabled) {
-      setOpen(true);
-    }
-  };
-  const closePicker = () => setOpen(false);
-  const togglePicker = () => {
-    if (!disabled) {
-      setOpen((prevOpen) => !prevOpen);
-    }
-  };
-  const handleTriggerKeyDown = (
-    event: React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    if (disabled) {
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      openPicker();
-    }
-  };
-  const handleChildTriggerKeyDown = (
-    event: React.KeyboardEvent<HTMLElement>
-  ) => {
-    if (disabled) {
-      return;
-    }
-
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      openPicker();
-    }
-  };
   const toggleViewLabel = "Toggle calendar view";
   const prevLabel =
     view === "date"
@@ -259,7 +132,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 openPicker,
                 closePicker,
                 togglePicker,
-                onTriggerKeyDown: handleChildTriggerKeyDown,
+                onTriggerKeyDown: handleTriggerKeyDown,
               })}
             </span>
           ) : (

--- a/packages/frappe-ui-react/src/components/datePicker/useDateRangePicker.ts
+++ b/packages/frappe-ui-react/src/components/datePicker/useDateRangePicker.ts
@@ -1,0 +1,151 @@
+/**
+ * External dependencies.
+ */
+import { useCallback, useState } from "react";
+
+/**
+ * Internal dependencies.
+ */
+import { useDatePicker } from "./useDatePicker";
+import { getDate, getDateValue } from "./utils";
+
+export function useDateRangePicker({
+  value,
+  onChange,
+}: {
+  value?: string[];
+  onChange?: (v: string[]) => void;
+}) {
+  // Selection state, used only when the range is not driven by `value`.
+  const [internalFrom, setInternalFrom] = useState<string>(value?.[0] || "");
+  const [internalTo, setInternalTo] = useState<string>(value?.[1] || "");
+  // Whether the next date click extends the current range instead of starting a new one.
+  const [isExtendingRange, setIsExtendingRange] = useState(false);
+
+  const isControlled = Array.isArray(value);
+  const fromDate = isControlled ? (value?.[0] ?? "") : internalFrom;
+  const toDate = isControlled ? (value?.[1] ?? "") : internalTo;
+
+  const {
+    open,
+    setOpen,
+    formattedMonth,
+    datesAsWeeks,
+    currentMonth,
+    currentYear,
+    view,
+    cycleView,
+    selectMonth,
+    selectYear,
+    yearRangeStart,
+    yearRange,
+    prev,
+    next,
+    resetView,
+    months,
+    today,
+    syncCalendarToValue,
+    resetCalendarToToday,
+  } = useDatePicker({
+    value: fromDate,
+    onChange: () => {},
+  });
+
+  const commitRange = useCallback(
+    (from: string, to: string) => {
+      setInternalFrom(from);
+      setInternalTo(to);
+      onChange?.([from, to]);
+    },
+    [onChange]
+  );
+
+  const handleDateClick = useCallback(
+    (date: Date): boolean => {
+      // Zero out time for date
+      const d = new Date(date);
+      d.setHours(0, 0, 0, 0);
+      const v = getDateValue(d);
+      syncCalendarToValue(v);
+
+      // Commit the start as a single-day range so the value never lags behind the calendar.
+      if (!isExtendingRange || !fromDate) {
+        setIsExtendingRange(true);
+        commitRange(v, v);
+        return false;
+      }
+
+      const isReversed = fromDate > v;
+      setIsExtendingRange(false);
+      commitRange(isReversed ? v : fromDate, isReversed ? fromDate : v);
+      return true;
+    },
+    [commitRange, fromDate, isExtendingRange, syncCalendarToValue]
+  );
+
+  const handleToday = useCallback(() => {
+    const d = new Date(today);
+    d.setHours(0, 0, 0, 0);
+    const todayStr = getDateValue(d);
+    syncCalendarToValue(todayStr);
+    setIsExtendingRange(false);
+    commitRange(todayStr, todayStr);
+  }, [commitRange, syncCalendarToValue, today]);
+
+  const clearDates = useCallback(() => {
+    syncCalendarToValue("");
+    resetCalendarToToday();
+    setIsExtendingRange(false);
+    commitRange("", "");
+  }, [commitRange, resetCalendarToToday, syncCalendarToValue]);
+
+  const selectDates = useCallback(() => {
+    onChange?.([fromDate, toDate]);
+    setOpen(false);
+  }, [fromDate, onChange, setOpen, toDate]);
+
+  const applyRange = useCallback(
+    (from: string, to: string) => {
+      syncCalendarToValue(from);
+      setIsExtendingRange(false);
+      commitRange(from, to);
+    },
+    [commitRange, syncCalendarToValue]
+  );
+
+  const isInRange = useCallback(
+    (date: Date) => {
+      if (!fromDate || !toDate) return false;
+      return date >= getDate(fromDate) && date <= getDate(toDate);
+    },
+    [fromDate, toDate]
+  );
+
+  return {
+    open,
+    setOpen,
+    fromDate,
+    toDate,
+    formattedMonth,
+    datesAsWeeks,
+    currentMonth,
+    currentYear,
+    view,
+    cycleView,
+    selectMonth,
+    selectYear,
+    yearRangeStart,
+    yearRange,
+    prev,
+    next,
+    resetView,
+    months,
+    today,
+    handleToday,
+    handleDateClick,
+    clearDates,
+    selectDates,
+    applyRange,
+    isInRange,
+  };
+}

--- a/packages/frappe-ui-react/src/components/datePicker/useDateRangePicker.ts
+++ b/packages/frappe-ui-react/src/components/datePicker/useDateRangePicker.ts
@@ -19,8 +19,6 @@ export function useDateRangePicker({
   // Selection state, used only when the range is not driven by `value`.
   const [internalFrom, setInternalFrom] = useState<string>(value?.[0] || "");
   const [internalTo, setInternalTo] = useState<string>(value?.[1] || "");
-  // Whether the next date click extends the current range instead of starting a new one.
-  const [isExtendingRange, setIsExtendingRange] = useState(false);
 
   const isControlled = Array.isArray(value);
   const fromDate = isControlled ? (value?.[0] ?? "") : internalFrom;
@@ -68,19 +66,17 @@ export function useDateRangePicker({
       const v = getDateValue(d);
       syncCalendarToValue(v);
 
-      // Commit the start as a single-day range so the value never lags behind the calendar.
-      if (!isExtendingRange || !fromDate) {
-        setIsExtendingRange(true);
-        commitRange(v, v);
+      // Starting a range commits the start date with a pending, empty end date.
+      if (!fromDate || toDate) {
+        commitRange(v, "");
         return false;
       }
 
       const isReversed = fromDate > v;
-      setIsExtendingRange(false);
       commitRange(isReversed ? v : fromDate, isReversed ? fromDate : v);
       return true;
     },
-    [commitRange, fromDate, isExtendingRange, syncCalendarToValue]
+    [commitRange, fromDate, syncCalendarToValue, toDate]
   );
 
   const handleToday = useCallback(() => {
@@ -88,14 +84,12 @@ export function useDateRangePicker({
     d.setHours(0, 0, 0, 0);
     const todayStr = getDateValue(d);
     syncCalendarToValue(todayStr);
-    setIsExtendingRange(false);
     commitRange(todayStr, todayStr);
   }, [commitRange, syncCalendarToValue, today]);
 
   const clearDates = useCallback(() => {
     syncCalendarToValue("");
     resetCalendarToToday();
-    setIsExtendingRange(false);
     commitRange("", "");
   }, [commitRange, resetCalendarToToday, syncCalendarToValue]);
 
@@ -107,7 +101,6 @@ export function useDateRangePicker({
   const applyRange = useCallback(
     (from: string, to: string) => {
       syncCalendarToValue(from);
-      setIsExtendingRange(false);
       commitRange(from, to);
     },
     [commitRange, syncCalendarToValue]


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

Selecting a range takes two clicks, but the first click never fired `onChange` while the trigger already displayed it, so the consumer's value silently disagreed with what the calendar showed. The `value` prop was also read only once at mount.

- `onChange` now fires on every click — `[start, ""]` on the first, an ordered pair on
  the second.
- `fromDate`/`toDate` derive from `value` when it's passed, internal state otherwise,
  so prop-driven resets work. 
- Also hook extracted to `useDateRangePicker.ts`.

<!-- What do we want to achieve with this PR? -->

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions to test the changes.
-->

## Screenshot/Screencast

No visual change.

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/1882
