### PR TITLE
fix: prevent text-sm descender clipping in Safari by using fixed line-height

### DIFF
--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -501,7 +501,7 @@ input {
     --text-xs-font-weight: 420;
 
     --text-sm-size: 13px;
-    --text-sm-line-height: 1.15;
+    --text-sm-line-height: 15px;
     --text-sm-letter-spacing: 0.02em;
     --text-sm-font-weight: 420;
 


### PR DESCRIPTION
## Description
- `--text-sm-line-height` was `1.15` (relative), which resolves to `14.95px` against the `13px` font size.
- Safari rounds this fractional line-height differently than other engines, leaving too little room below the baseline and clipping descenders (g, p, y, etc.) in `text-sm` content.
- Changed the token to a fixed `15px` line-height so the value is a whole pixel and consistent across browsers.

## Relevant Technical Choices
Used `15px` (fixed value) instead of `1.1538` (relative value) as both will result in same value since the font size is fixed `13px`, and the former is more readable and easy to reason about.

## Additional Information:
Root cause: Font size only defines the em-square, not the actual visible glyph height — actual rendering also depends on the font's ascent/descent/line-gap metrics. When `line-height` is a fractional pixel value (`1.15 * 13px = 14.95px`), browsers must round it to physical pixels, and different rendering engines round differently. Safari's rounding reduces the space available for descenders, causing clipping even though `14.95px > 13px`. Using a whole-pixel line-height avoids the rounding ambiguity.

## Screenshot/Screencast
Before:
<img width="1358" height="136" alt="image" src="https://github.com/user-attachments/assets/60f8b3f7-cfd8-49d0-9177-3ced9ab715b5" />
<img width="370" height="236" alt="image" src="https://github.com/user-attachments/assets/43d2aef0-f804-44f6-b958-29333a56f911" />

After:
<img width="810" height="102" alt="image" src="https://github.com/user-attachments/assets/d84817c9-a14f-49d4-80ad-50cddd94f7b0" />
<img width="486" height="252" alt="image" src="https://github.com/user-attachments/assets/4c2cd379-0b30-4c2b-86c6-478363afced0" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

fixes: https://github.com/rtCamp/next-pms/issues/1862