### PR TITLE
feat: add opt-in matchTriggerWidth prop to constrain select dropdown width

### DIFF
--- a/packages/frappe-ui-react/src/components/select/select.stories.tsx
+++ b/packages/frappe-ui-react/src/components/select/select.stories.tsx
@@ -47,6 +47,11 @@ export default {
       action: "changed",
       description: "Callback function when the selected value changes",
     },
+    matchTriggerWidth: {
+      control: "boolean",
+      description:
+        "If true, constrains the dropdown width to match the trigger width",
+    },
   },
 } as Meta<typeof Select>;
 
@@ -127,6 +132,27 @@ export const WithSuffix: StoryObj<SelectProps> = {
     options: OPTIONS,
     placeholder: "Select option",
     suffix: () => <User size={16} className="text-ink-gray-9" />,
+  },
+  render: (args) => {
+    const [value, setValue] = useState(args.value || "");
+
+    return (
+      <Select
+        {...args}
+        value={value}
+        onChange={(value) => setValue(value ?? "")}
+      />
+    );
+  },
+};
+
+export const WithMatchTriggerWidth: StoryObj<SelectProps> = {
+  args: {
+    value: "",
+    options: OPTIONS,
+    placeholder: "Select option",
+    matchTriggerWidth: true,
+    className: "w-40",
   },
   render: (args) => {
     const [value, setValue] = useState(args.value || "");

--- a/packages/frappe-ui-react/src/components/select/select.tsx
+++ b/packages/frappe-ui-react/src/components/select/select.tsx
@@ -38,6 +38,7 @@ const Select: React.FC<SelectProps> = ({
   onChange,
   className,
   placeholderClassName,
+  matchTriggerWidth = false,
 }) => {
   const Prefix = prefix ?? DefaultPrefix;
   const Suffix = suffix ?? DefaultSuffix;
@@ -74,19 +75,24 @@ const Select: React.FC<SelectProps> = ({
       </BaseSelect.Trigger>
       <BaseSelect.Portal>
         <BaseSelect.Positioner className="z-60">
-          <BaseSelect.Popup className="p-1 m-0 bg-surface-modal ring-1 ring-outline-gray-1 ring-opacity-5 rounded-lg shadow-2xl will-change-[opacity,transform] overflow-hidden origin-center data-[state=open]:animate-[fadeInScale_100ms] data-[state=closed]:animate-[fadeOutScale_100ms]">
+          <BaseSelect.Popup
+            className={cn(
+              "p-1 m-0 bg-surface-modal ring-1 ring-outline-gray-1 ring-opacity-5 rounded-lg shadow-2xl will-change-[opacity,transform] overflow-hidden origin-center data-[state=open]:animate-[fadeInScale_100ms] data-[state=closed]:animate-[fadeOutScale_100ms]",
+              matchTriggerWidth && "w-(--anchor-width)"
+            )}
+          >
             <BaseSelect.List className="max-h-60 overflow-auto">
               {options.map((option) => (
                 <BaseSelect.Item
                   key={option.value}
                   value={option.value}
                   disabled={option.disabled}
-                  className="focus:outline-none rounded min-h-7 px-2 text-base text-ink-gray-9 flex items-center data-highlighted:bg-surface-gray-2 border-0 data-selected:bg-surface-gray-2 data-disabled:text-ink-gray-4 select-none"
+                  className="focus:outline-none rounded min-h-7 px-2 py-1 text-base text-ink-gray-9 flex items-start data-highlighted:bg-surface-gray-2 border-0 data-selected:bg-surface-gray-2 data-disabled:text-ink-gray-4 select-none"
                 >
-                  <BaseSelect.ItemText className="truncate">
+                  <BaseSelect.ItemText className="wrap-break-word min-w-0 flex-1">
                     <Option option={option} />
                   </BaseSelect.ItemText>
-                  <BaseSelect.ItemIndicator className="ml-auto pl-1 inline-flex items-center justify-center">
+                  <BaseSelect.ItemIndicator className="ml-auto pl-1 inline-flex items-center justify-center shrink-0">
                     <Check className="h-4 w-4" />
                   </BaseSelect.ItemIndicator>
                 </BaseSelect.Item>

--- a/packages/frappe-ui-react/src/components/select/types.ts
+++ b/packages/frappe-ui-react/src/components/select/types.ts
@@ -19,6 +19,7 @@ export interface SelectProps {
   options: SelectOption[];
   className?: string;
   placeholderClassName?: string;
+  matchTriggerWidth?: boolean;
   prefix?: () => ReactNode;
   suffix?: () => ReactNode;
   option?: ({ option }: { option: SelectOption }) => ReactNode;


### PR DESCRIPTION
## Description
Select's popup sized itself to its widest option regardless of trigger width, letting long labels overflow past adjacent elements. Adds a matchTriggerWidth prop (default false, no change for existing consumers) that binds the popup to the trigger's width, matching the pattern already used by Combobox/MultiSelect/AutoComplete. Also switches ItemText from truncate to break-words so long labels wrap across lines instead of getting cut off with no way to read the rest.

<img width="1792" height="682" alt="image" src="https://github.com/user-attachments/assets/ca6285f3-64ee-408d-b5b6-28b7d992aa4b" />

## Screenshot/Screencast
<img width="1796" height="914" alt="image" src="https://github.com/user-attachments/assets/db859dfa-fc46-49c7-a8f7-e6a7c2f74b99" />

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).