### PR TITLE
fix(date-picker): add proper focus highlighting

### DIFF
--- a/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
@@ -104,11 +104,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <Popover.Trigger
-        disabled={disabled}
-        nativeButton={false}
-        render={
-          children ? (
+      {children ? (
+        <Popover.Trigger
+          disabled={disabled}
+          nativeButton={false}
+          className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          render={
             <span className="!mb-0">
               {children({
                 isOpen: open,
@@ -120,27 +121,38 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                 onTriggerKeyDown: handleChildTriggerKeyDown,
               })}
             </span>
-          ) : (
-            <div className="flex w-full flex-col space-y-1.5">
-              {label && (
-                <label className="block text-xs text-ink-gray-5">{label}</label>
-              )}
-              <TextInput
-                type="text"
-                placeholder={placeholder}
-                value={displayValue}
-                disabled={disabled}
-                readOnly
-                onKeyDown={handleTriggerKeyDown}
-                suffix={() => (
-                  <FeatherIcon name="chevron-down" className="w-4 h-4" />
-                )}
-                variant={variant}
-              />
-            </div>
-          )
-        }
-      />
+          }
+        />
+      ) : (
+        <div className="flex w-full flex-col space-y-1.5">
+          {label && (
+            <label className="block text-xs text-ink-gray-5">{label}</label>
+          )}
+          <Popover.Trigger
+            disabled={disabled}
+            nativeButton={false}
+            className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+            render={
+              <div>
+                <TextInput
+                  type="text"
+                  placeholder={placeholder}
+                  value={displayValue}
+                  disabled={disabled}
+                  readOnly
+                  tabIndex={-1}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onKeyDown={handleTriggerKeyDown}
+                  suffix={() => (
+                    <FeatherIcon name="chevron-down" className="w-4 h-4" />
+                  )}
+                  variant={variant}
+                />
+              </div>
+            }
+          />
+        </div>
+      )}
 
       <Popover.Portal>
         <Popover.Positioner

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -119,12 +119,12 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <Popover.Trigger
-        disabled={disabled}
-        nativeButton={false}
-        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
-        render={
-          children ? (
+      {children ? (
+        <Popover.Trigger
+          disabled={disabled}
+          nativeButton={false}
+          className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          render={
             <span>
               {children({
                 isOpen: open,
@@ -136,26 +136,37 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                 onTriggerKeyDown: handleTriggerKeyDown,
               })}
             </span>
-          ) : (
-            <div className="flex w-full flex-col space-y-1.5">
-              {label && (
-                <label className="block text-xs text-ink-gray-5">{label}</label>
-              )}
-              <TextInput
-                type="text"
-                placeholder={placeholder}
-                value={displayValue}
-                disabled={disabled}
-                readOnly
-                onKeyDown={handleTriggerKeyDown}
-                suffix={() => (
-                  <FeatherIcon name="chevron-down" className="w-4 h-4" />
-                )}
-              />
-            </div>
-          )
-        }
-      />
+          }
+        />
+      ) : (
+        <div className="flex w-full flex-col space-y-1.5">
+          {label && (
+            <label className="block text-xs text-ink-gray-5">{label}</label>
+          )}
+          <Popover.Trigger
+            disabled={disabled}
+            nativeButton={false}
+            className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+            render={
+              <div>
+                <TextInput
+                  type="text"
+                  placeholder={placeholder}
+                  value={displayValue}
+                  disabled={disabled}
+                  readOnly
+                  tabIndex={-1}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onKeyDown={handleTriggerKeyDown}
+                  suffix={() => (
+                    <FeatherIcon name="chevron-down" className="w-4 h-4" />
+                  )}
+                />
+              </div>
+            }
+          />
+        </div>
+      )}
 
       <Popover.Portal>
         <Popover.Positioner

--- a/packages/frappe-ui-react/src/components/datePicker/dateTimePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateTimePicker.tsx
@@ -136,11 +136,12 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
 
   return (
     <Popover.Root open={open} onOpenChange={handleOpenChange}>
-      <Popover.Trigger
-        disabled={disabled}
-        nativeButton={false}
-        render={
-          children ? (
+      {children ? (
+        <Popover.Trigger
+          disabled={disabled}
+          nativeButton={false}
+          className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          render={
             <span>
               {children({
                 isOpen: open,
@@ -152,26 +153,37 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
                 onTriggerKeyDown: handleChildTriggerKeyDown,
               })}
             </span>
-          ) : (
-            <div className="flex w-full flex-col space-y-1.5">
-              {label && (
-                <label className="block text-xs text-ink-gray-5">{label}</label>
-              )}
-              <TextInput
-                type="text"
-                placeholder={placeholder}
-                value={formattedDisplayValue}
-                disabled={disabled}
-                readOnly
-                onKeyDown={handleTriggerKeyDown}
-                suffix={() => (
-                  <FeatherIcon name="chevron-down" className="w-4 h-4" />
-                )}
-              />
-            </div>
-          )
-        }
-      />
+          }
+        />
+      ) : (
+        <div className="flex w-full flex-col space-y-1.5">
+          {label && (
+            <label className="block text-xs text-ink-gray-5">{label}</label>
+          )}
+          <Popover.Trigger
+            disabled={disabled}
+            nativeButton={false}
+            className="block rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+            render={
+              <div>
+                <TextInput
+                  type="text"
+                  placeholder={placeholder}
+                  value={formattedDisplayValue}
+                  disabled={disabled}
+                  readOnly
+                  tabIndex={-1}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onKeyDown={handleTriggerKeyDown}
+                  suffix={() => (
+                    <FeatherIcon name="chevron-down" className="w-4 h-4" />
+                  )}
+                />
+              </div>
+            }
+          />
+        </div>
+      )}
 
       <Popover.Portal>
         <Popover.Positioner

--- a/packages/frappe-ui-react/src/components/textInput/types.ts
+++ b/packages/frappe-ui-react/src/components/textInput/types.ts
@@ -1,4 +1,4 @@
-import type { KeyboardEventHandler, ReactNode } from "react";
+import type { KeyboardEventHandler, MouseEventHandler, ReactNode } from "react";
 import type { TextInputTypes } from "../../common/types";
 
 // Only these input types honor min/max/step per the HTML spec.
@@ -17,8 +17,10 @@ export interface TextInputBaseProps {
   debounce?: number;
   required?: boolean;
   readOnly?: boolean;
+  tabIndex?: number;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+  onMouseDown?: MouseEventHandler<HTMLInputElement>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   prefix?: (args?: any) => ReactNode;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

### Problem

DatePicker, DateRangePicker, and DateTimePicker wrapped the TextInput in a Popover.Trigger whose render prop pointed at the inner TextInput. Because the focusable/interactive element was the input itself, the focus-visible ring on Popover.Trigger never rendered where expected.

### Fix

- Moved Popover.Trigger to wrap the label/input container directly (instead of being deep inside the render render-prop) so the focus-visible:ring-2 focus-visible:ring-outline-gray-3 classes apply to the correct element, in all three components (datePicker.tsx, dateRangePicker.tsx, dateTimePicker.tsx).
- Set tabIndex={-1} and onMouseDown={(e) => e.preventDefault()} on the inner TextInput so it no longer steals focus/tab order from the trigger — the trigger itself now receives focus and shows the highlight ring.

## Screenshot/Screencast
Before:
<img width="1902" height="636" alt="image" src="https://github.com/user-attachments/assets/5ee5df8d-c494-4cc1-b7d9-48dccac67e73" />

After:
<img width="1796" height="568" alt="image" src="https://github.com/user-attachments/assets/0c46f0d8-d462-41ff-a79e-9b3471e14a99" />


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
