### PR TITLE
fix(select): dropdown ring color silently stripped in production builds

### DIFF
--- a/packages/frappe-ui-react/src/components/select/select.tsx
+++ b/packages/frappe-ui-react/src/components/select/select.tsx
@@ -77,7 +77,7 @@ const Select: React.FC<SelectProps> = ({
         <BaseSelect.Positioner className="z-60">
           <BaseSelect.Popup
             className={cn(
-              "p-1 m-0 bg-surface-modal ring-1 ring-outline-gray-1 ring-opacity-5 rounded-lg shadow-2xl will-change-[opacity,transform] overflow-hidden origin-center data-[state=open]:animate-[fadeInScale_100ms] data-[state=closed]:animate-[fadeOutScale_100ms]",
+              "p-1 m-0 bg-surface-modal ring-1 ring-outline-gray-1/5 rounded-lg shadow-2xl will-change-[opacity,transform] overflow-hidden origin-center data-[state=open]:animate-[fadeInScale_100ms] data-[state=closed]:animate-[fadeOutScale_100ms]",
               matchTriggerWidth && "w-(--anchor-width)"
             )}
           >


### PR DESCRIPTION
## Description

### Root cause:
ring-opacity-5 is a Tailwind v3 utility with no effect under Tailwind v4 (opacity is now expressed via a /opacity modifier on the color class). tailwind-merge v3.5.0 — the version this package declares and the version any real production build resolves — treats ring-outline-gray-1 and ring-opacity-5 as conflicting members of the same class group and drops the earlier one, silently deleting the color class.

This didn't show up locally because vite dev's dependency optimizer dedupes all tailwind-merge imports in the app graph down to a single shared copy, which happened to be an older v2 install elsewhere in the monorepo that doesn't have this class-group bug. A real build (vite build, same as staging) resolves this package's own v3.5.0 dependency instead, exposing the bug.

## Screenshot/Screencast
Before:
<img width="1130" height="812" alt="image" src="https://github.com/user-attachments/assets/d27477fa-e525-4995-9893-a99ccf3737e7" />

After:
<img width="1170" height="778" alt="image" src="https://github.com/user-attachments/assets/fcd7113a-a61f-4f40-820d-5830e22c42c2" />


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).
