### PR TITLE
feat: add clear icon in combobox component

### DIFF
--- a/packages/frappe-ui-react/src/components/combobox/combobox.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.interactions.stories.tsx
@@ -194,3 +194,44 @@ export const ControlledSearchLoading: Story = {
     expect(page.queryByText("John Doe")).not.toBeInTheDocument();
   },
 };
+
+export const Clearable: Story = {
+  args: {
+    options: simpleOptions,
+    value: "cherry",
+    placeholder: "Select an item",
+    clearable: true,
+    onChange: fn(),
+  },
+  render: function Render(args) {
+    const [value, setValue] = React.useState<string | null>("cherry");
+
+    return (
+      <div className="w-80">
+        <Combobox
+          {...args}
+          value={value}
+          onChange={(nextValue, selectedOption) => {
+            setValue(nextValue);
+            args.onChange?.(nextValue, selectedOption);
+          }}
+        />
+      </div>
+    );
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("combobox");
+    const clearButton = canvas.getByRole("button", {
+      name: "Clear selection",
+    });
+
+    await userEvent.click(clearButton);
+
+    await expect(args.onChange).toHaveBeenCalledWith(null, null);
+
+    await waitFor(() => {
+      expect(input).toHaveValue("");
+    });
+  },
+};

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -30,13 +30,14 @@ import {
   isGroupedOption,
 } from "./utils";
 import { cn } from "../../utils";
-import { Check, SmallDown } from "../../icons";
+import { Check, SmallClose, SmallDown } from "../../icons";
 
 export const Combobox: React.FC<ComboboxProps> = ({
   options,
   value,
   placeholder,
   disabled,
+  clearable = false,
   openOnFocus = false,
   searchValue,
   onSearchChange,
@@ -160,6 +161,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
   const showOptionsPanel = filteredOptions.length > 0 || showEmptyState;
 
   const hasSelectedIcon = Boolean(selectedOption && getIcon(selectedOption));
+  const showClear = clearable && Boolean(value);
 
   const isSameOption = useCallback(
     (option: SimpleOption | null, candidate: SimpleOption | null) => {
@@ -198,13 +200,29 @@ export const Combobox: React.FC<ComboboxProps> = ({
             className={cn(
               "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 outline-none focus:border-outline-gray-4 focus:ring-2 focus:ring-outline-gray-3 disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
               hasSelectedIcon ? "pl-8" : "pl-2",
-              loading ? "pr-12" : "pr-8",
+              showClear
+                ? loading
+                  ? "pr-16"
+                  : "pr-12"
+                : loading
+                  ? "pr-12"
+                  : "pr-8",
               inputClassName
             )}
             placeholder={placeholder}
             onFocus={handleFocus}
             autoComplete="off"
           />
+          {showClear && (
+            <button
+              type="button"
+              aria-label="Clear selection"
+              className="absolute inset-y-0 right-8 flex items-center text-ink-gray-4 transition-colors hover:text-ink-gray-7"
+              onClick={() => handleChange(null)}
+            >
+              <SmallClose className="size-4" />
+            </button>
+          )}
           <BaseCombobox.Trigger
             aria-label="Toggle options"
             className="absolute inset-y-0 right-0 flex items-center gap-1 pr-2 text-ink-gray-4"

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -216,8 +216,9 @@ export const Combobox: React.FC<ComboboxProps> = ({
           {showClear && (
             <button
               type="button"
+              disabled={disabled}
               aria-label="Clear selection"
-              className="absolute inset-y-0 right-8 flex items-center text-ink-gray-4 transition-colors hover:text-ink-gray-7"
+              className="absolute inset-y-0 right-8 flex items-center text-ink-gray-4 transition-colors hover:text-ink-gray-7 disabled:pointer-events-none disabled:text-ink-gray-5"
               onClick={() => handleChange(null)}
             >
               <SmallClose className="size-4" />

--- a/packages/frappe-ui-react/src/components/combobox/types.ts
+++ b/packages/frappe-ui-react/src/components/combobox/types.ts
@@ -16,6 +16,7 @@ export interface ComboboxProps {
   value?: string | null;
   placeholder?: string;
   disabled?: boolean;
+  clearable?: boolean;
   openOnFocus?: boolean;
   searchValue?: string;
   onSearchChange?: (value: string) => void;


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

Adds a new optional prop which renders a clear button for the selection to be cleared in the combobox component

## Screenshot/Screencast

<img width="143" height="92" alt="image" src="https://github.com/user-attachments/assets/0c804e14-d264-4c8f-b6d2-19473f9e30cf" />

<img width="246" height="355" alt="image" src="https://github.com/user-attachments/assets/ca9a4d1c-cf30-4819-8a4c-a98d21b96f57" />


https://github.com/user-attachments/assets/7e9965e8-93e9-4ea6-a04a-dea44c129d1d



---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Required for: https://github.com/rtCamp/next-pms/issues/2023
