### PR TITLE
feat(form-label, duration-input): support required-field indicators

### DIFF
--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
@@ -154,6 +154,7 @@ const durationSpinnerVariants = cva(
 
 const DurationInput = ({
   label,
+  required = false,
   inlineLabel,
   maxDuration = 8,
   hoursLeft = 8,
@@ -277,7 +278,18 @@ const DurationInput = ({
             classNames.header
           )}
         >
-          <Slider.Label className={cn(classNames.label)}>{label}</Slider.Label>
+          <Slider.Label className={cn(classNames.label)}>
+            {label}
+            {required && (
+              <>
+                <span className="text-ink-red-3 select-none" aria-hidden="true">
+                  {" "}
+                  *
+                </span>
+                <span className="sr-only">(required)</span>
+              </>
+            )}
+          </Slider.Label>
           <p
             className={cn(
               isOverHours && "text-ink-red-4",

--- a/packages/frappe-ui-react/src/components/durationInput/types.ts
+++ b/packages/frappe-ui-react/src/components/durationInput/types.ts
@@ -30,6 +30,8 @@ export interface DurationInputClassNames {
 export interface DurationInputProps {
   /** Label displayed above the input. */
   label?: string | false;
+  /** If true, appends a required-field asterisk to the label. */
+  required?: boolean;
   /** Label displayed inside the input. */
   inlineLabel?: string;
   /** Maximum allowed duration in hours. */

--- a/packages/frappe-ui-react/src/components/formLabel.stories.tsx
+++ b/packages/frappe-ui-react/src/components/formLabel.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import FormLabel from "./formLabel";
+
+const meta: Meta<typeof FormLabel> = {
+  title: "Components/FormLabel",
+  component: FormLabel,
+  parameters: { docs: { source: { type: "dynamic" } }, layout: "centered" },
+  tags: ["autodocs"],
+  argTypes: {
+    label: {
+      control: "text",
+      description: "Label text (used when children is not provided)",
+    },
+    children: {
+      control: "text",
+      description: "Label content, takes precedence over label",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md"],
+      description: "Typography size of the label",
+    },
+    required: {
+      control: "boolean",
+      description: "If true, renders a required-field asterisk",
+    },
+    className: {
+      control: "text",
+      description: "Additional classes merged onto the default label classes",
+    },
+  },
+  args: {
+    label: "Label",
+    size: "sm",
+    required: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Required: Story = {
+  args: { required: true },
+};
+
+export const MediumSize: Story = {
+  args: { size: "md", required: true },
+};
+
+export const WithChildren: Story = {
+  args: {
+    label: undefined,
+    children: "Custom label content",
+    required: true,
+  },
+};
+
+export const WithCustomSpacing: Story = {
+  args: {
+    size: "md",
+    required: true,
+    className: "mb-1.5",
+  },
+};

--- a/packages/frappe-ui-react/src/components/formLabel.tsx
+++ b/packages/frappe-ui-react/src/components/formLabel.tsx
@@ -1,34 +1,43 @@
 import React, { useMemo } from "react";
 
+import { cn } from "../utils/cn";
+
 export type Size = "sm" | "md";
 
 export interface FormLabelProps {
-  label: string;
+  label?: string;
+  children?: React.ReactNode;
   size?: Size;
   id?: string;
   required?: boolean;
+  className?: string;
 }
 
 const FormLabel: React.FC<FormLabelProps> = ({
   label,
+  children,
   size = "sm",
   id,
   required = false,
+  className,
 }) => {
   const labelClasses = useMemo(() => {
     const sizeClasses = {
       sm: "text-xs",
       md: "text-base",
     }[size];
-    return `block ${sizeClasses} text-ink-gray-5`;
-  }, [size]);
+    return cn("block", sizeClasses, "text-ink-gray-5", className);
+  }, [size, className]);
 
   return (
     <label className={labelClasses} htmlFor={id} data-testid="form-label">
-      {label}
+      {children ?? label}
       {required && (
         <>
-          <span className="text-ink-red-3 select-none" aria-hidden="true">
+          <span
+            className="text-ink-red-3 select-none ml-0.5"
+            aria-hidden="true"
+          >
             *
           </span>
           <span className="sr-only">(required)</span>


### PR DESCRIPTION
## Description
Extends `FormLabel` and `DurationInput` so consuming apps can mark a field as required, enabling consistent required-field asterisks across forms.

## Screenshot/Screencast
<img width="2858" height="1372" alt="image" src="https://github.com/user-attachments/assets/a6360076-2dbf-49d1-b43f-1987a3432834" />


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Partially addresses https://github.com/rtCamp/next-pms/issues/2024