### PR TITLE
Fix: formatter to show HH:MM

### DIFF
--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.interactions.stories.tsx
@@ -171,7 +171,7 @@ export const Slider: Story = {
     await waitFor(() => {
       expect(args.onChange).toHaveBeenLastCalledWith(4.5);
       expect(canvas.getByRole("textbox")).toHaveValue("04:30");
-      expect(canvas.getByText("0.5h over")).toHaveClass("text-ink-red-4");
+      expect(canvas.getByText("30m over")).toHaveClass("text-ink-red-4");
     });
   },
 };

--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.stories.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.stories.tsx
@@ -35,7 +35,7 @@ export default {
     hoursLeft: {
       control: "number",
       description:
-        "Remaining time available in hours (used to calculate 'X h left' or 'X h over')",
+        "Remaining time available in hours (used to calculate 'Xh Ym left' or 'Xh Ym over')",
     },
     snap: {
       control: "select",

--- a/packages/frappe-ui-react/src/components/durationInput/utils.ts
+++ b/packages/frappe-ui-react/src/components/durationInput/utils.ts
@@ -176,8 +176,24 @@ export const sanitizeHoursInput = (value: string): string => {
  * Formats the balance text shown above the control.
  *
  * @param value - Balance in hours.
- * @returns Balance text with the `h` suffix.
+ * @returns Balance text in `Xh Ym` form (e.g. `10m`, `1h 30m`, `8h`).
  */
 export const formatHoursBalance = (value: number): string => {
-  return `${Number(value.toFixed(2)).toString()}h`;
+  const totalMinutes = Math.round(value * 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (totalMinutes === 0) {
+    return "0h";
+  }
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
+
+  return `${hours}h ${minutes}m`;
 };


### PR DESCRIPTION
## Description

Updating formatter to show remaining hours in HH:MM format rather than fractions.

## Screenshot/Screencast

<img width="370" height="427" alt="image" src="https://github.com/user-attachments/assets/5933708e-1ce4-4ec6-bb69-4cb73a5b9135" />


## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/next-pms/issues/2020
