### PR TITLE
Feature: add truncation detection to the Tooltip component

### DIFF
--- a/packages/frappe-ui-react/src/components/tooltip/tooltip.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tooltip/tooltip.interactions.stories.tsx
@@ -1,0 +1,75 @@
+import { useRef } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+
+import Tooltip from "./tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+  title: "Components/Tooltip/Interactions",
+  component: Tooltip,
+  parameters: {
+    docs: { source: { type: "dynamic" } },
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+const LABEL = "John Doe";
+
+function TruncationCases() {
+  const clippedRef = useRef<HTMLSpanElement>(null);
+  const fittingRef = useRef<HTMLSpanElement>(null);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Tooltip
+        text={LABEL}
+        showWhen="truncated"
+        truncationRef={fittingRef}
+        hoverDelay={0}
+      >
+        <span data-testid="fitting-trigger" className="flex w-96 gap-2">
+          <span ref={fittingRef} className="truncate">
+            {LABEL}
+          </span>
+        </span>
+      </Tooltip>
+
+      <Tooltip
+        text={LABEL}
+        showWhen="truncated"
+        truncationRef={clippedRef}
+        hoverDelay={0}
+      >
+        <span data-testid="clipped-trigger" className="flex w-12 gap-2">
+          <span ref={clippedRef} className="truncate">
+            {LABEL}
+          </span>
+        </span>
+      </Tooltip>
+    </div>
+  );
+}
+
+export const ShowWhenTruncated: Story = {
+  render: () => <TruncationCases />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.hover(canvas.getByTestId("fitting-trigger"));
+    expect(screen.queryByTestId("tooltip-popup")).not.toBeInTheDocument();
+
+    await userEvent.hover(canvas.getByTestId("clipped-trigger"));
+    await waitFor(() => {
+      expect(screen.getByTestId("tooltip-popup")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("tooltip-popup")).toHaveTextContent(LABEL);
+
+    await userEvent.unhover(canvas.getByTestId("clipped-trigger"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("tooltip-popup")).not.toBeInTheDocument();
+    });
+  },
+};

--- a/packages/frappe-ui-react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frappe-ui-react/src/components/tooltip/tooltip.stories.tsx
@@ -37,6 +37,17 @@ const meta: Meta<typeof Tooltip> = {
       control: "text",
       description: "Custom CSS classes for the tooltip arrow",
     },
+    showWhen: {
+      control: "select",
+      options: ["always", "truncated"],
+      description:
+        "Determines when the tooltip should be shown. 'always' shows the tooltip on hover, 'truncated' shows it only when the text is truncated.",
+    },
+    truncationRef: {
+      control: false,
+      description:
+        "A ref to the element that should be checked for truncation. If not provided, the trigger element will be used.",
+    },
   },
   args: {
     placement: "top",

--- a/packages/frappe-ui-react/src/components/tooltip/tooltip.tsx
+++ b/packages/frappe-ui-react/src/components/tooltip/tooltip.tsx
@@ -1,7 +1,15 @@
-import React, { useMemo } from "react";
-import type { TooltipProps } from "./types";
+/**
+ * External dependencies.
+ */
+import React, { useCallback, useMemo, useRef } from "react";
 import { Tooltip } from "@base-ui/react/tooltip";
 import clsx from "clsx";
+
+/**
+ * Internal dependencies.
+ */
+import type { TooltipProps } from "./types";
+import { isTextTruncated } from "./utils";
 
 const TooltipComponent: React.FC<TooltipProps> = ({
   children,
@@ -11,8 +19,26 @@ const TooltipComponent: React.FC<TooltipProps> = ({
   hoverDelay = 0.5,
   arrowClass = "fill-surface-gray-7",
   disabled = false,
+  showWhen = "always",
+  truncationRef,
 }) => {
   const delayDuration = useMemo(() => hoverDelay * 1000, [hoverDelay]);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const setTriggerRef = useCallback((node: HTMLElement | null) => {
+    triggerRef.current = node;
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (open: boolean, eventDetails: Tooltip.Root.ChangeEventDetails) => {
+      const target = truncationRef?.current ?? triggerRef.current;
+
+      if (open && !isTextTruncated(target)) {
+        eventDetails.cancel();
+      }
+    },
+    [truncationRef]
+  );
 
   const tooltipContent = useMemo(() => {
     if (body) {
@@ -36,8 +62,13 @@ const TooltipComponent: React.FC<TooltipProps> = ({
 
   return (
     <Tooltip.Provider delay={delayDuration}>
-      <Tooltip.Root>
-        <Tooltip.Trigger render={children as React.ReactElement} />
+      <Tooltip.Root
+        onOpenChange={showWhen === "truncated" ? handleOpenChange : undefined}
+      >
+        <Tooltip.Trigger
+          ref={setTriggerRef}
+          render={children as React.ReactElement}
+        />
         <Tooltip.Portal>
           {tooltipContent && (
             <Tooltip.Positioner

--- a/packages/frappe-ui-react/src/components/tooltip/types.ts
+++ b/packages/frappe-ui-react/src/components/tooltip/types.ts
@@ -1,6 +1,11 @@
-import type { ReactNode } from "react";
+/**
+ * External dependencies.
+ */
+import type { ReactNode, RefObject } from "react";
 
 export type TooltipPlacement = "top" | "right" | "bottom" | "left";
+
+export type TooltipShowWhen = "always" | "truncated";
 
 export interface TooltipProps {
   children: ReactNode;
@@ -10,4 +15,8 @@ export interface TooltipProps {
   hoverDelay?: number; // In seconds
   arrowClass?: string;
   disabled?: boolean;
+  /** Determines when the tooltip should be shown. */
+  showWhen?: TooltipShowWhen;
+  /** A ref to the element that should be checked for truncation. */
+  truncationRef?: RefObject<HTMLElement | null>;
 }

--- a/packages/frappe-ui-react/src/components/tooltip/utils.ts
+++ b/packages/frappe-ui-react/src/components/tooltip/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether an element's text is clipped by `truncate`.
+ *
+ * CSS exposes no truncation state, so layout is the only source of truth:
+ * `scrollWidth` counts the text hidden by `overflow: hidden`, `clientWidth`
+ * counts what stays visible.
+ */
+export const isTextTruncated = (element: HTMLElement | null) => {
+  if (!element) {
+    return false;
+  }
+
+  return element.scrollWidth > element.clientWidth;
+};


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This pull request introduces a new feature to the `Tooltip` component, allowing tooltips to be shown only when the associated text is visually truncated.

## Relevant Technical Choices

<!-- Please describe your changes. -->
* Added a new `showWhen` prop (`"always"` or `"truncated"`) and an optional `truncationRef` prop to `TooltipProps`, allowing tooltips to appear only when the referenced element's text is truncated.


## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->

https://github.com/user-attachments/assets/b266a73b-2af8-4e22-99b4-4b19c84cac0b


---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially fixes https://github.com/rtCamp/next-pms/issues/2052
