### PR TITLE
fix: standardize keyboard focus rings across components

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -299,7 +299,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
     <button
       type="button"
       className={cn(
-        "flex h-7 w-full max-w-md items-center justify-between gap-2 rounded border border-transparent bg-surface-gray-2 px-2 py-1 transition-colors hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:outline-none focus:ring-2 focus:ring-outline-gray-3 data-popup-open:bg-surface-gray-3",
+        "flex h-7 w-full max-w-md items-center justify-between gap-2 rounded border border-transparent bg-surface-gray-2 px-2 py-1 transition-[background-color,border-color,box-shadow] hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:outline-2 focus:outline-default data-popup-open:bg-surface-gray-3",
         triggerClassName
       )}
     >

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -299,7 +299,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
     <button
       type="button"
       className={cn(
-        "flex h-7 w-full max-w-md items-center justify-between gap-2 rounded border border-transparent bg-surface-gray-2 px-2 py-1 transition-[background-color,border-color,box-shadow] hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:outline-2 focus:outline-default data-popup-open:bg-surface-gray-3",
+        "flex h-7 w-full max-w-md items-center justify-between gap-2 rounded border border-transparent bg-surface-gray-2 px-2 py-1 transition-[background-color,border-color,box-shadow] hover:bg-surface-gray-3 focus:outline-2 focus:outline-default data-popup-open:bg-surface-gray-3",
         triggerClassName
       )}
     >

--- a/packages/frappe-ui-react/src/components/breadcrumbs/variants.ts
+++ b/packages/frappe-ui-react/src/components/breadcrumbs/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const crumbVariants = cva(
-  "flex items-center rounded px-1.25 py-1 gap-1 font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+  "flex items-center rounded px-1.25 py-1 gap-1 font-medium focus-visible:outline-2 focus-visible:outline-default",
   {
     variants: {
       size: {

--- a/packages/frappe-ui-react/src/components/button/button.tsx
+++ b/packages/frappe-ui-react/src/components/button/button.tsx
@@ -65,10 +65,10 @@ const Button = ({
   }[theme];
 
   const focusClasses = {
-    gray: "focus-visible:ring focus-visible:ring-outline-gray-3",
-    blue: "focus-visible:ring focus-visible:ring-blue-400",
-    green: "focus-visible:ring focus-visible:ring-outline-green-2",
-    red: "focus-visible:ring focus-visible:ring-outline-red-2",
+    gray: "focus-visible:[outline:var(--focus-outline-default)]",
+    blue: "focus-visible:[outline:var(--focus-outline-blue)]",
+    green: "focus-visible:[outline:var(--focus-outline-green)]",
+    red: "focus-visible:[outline:var(--focus-outline-red)]",
   }[theme];
 
   const variantClasses = {
@@ -140,7 +140,7 @@ const Button = ({
   }[size];
 
   const buttonClasses = cn(
-    "inline-flex items-center justify-center gap-2 transition-colors focus:outline-none",
+    "inline-flex items-center justify-center gap-2 transition-colors",
     isDisabled ? disabledClasses : variantClasses,
     focusClasses,
     sizeClasses,

--- a/packages/frappe-ui-react/src/components/button/button.tsx
+++ b/packages/frappe-ui-react/src/components/button/button.tsx
@@ -65,10 +65,10 @@ const Button = ({
   }[theme];
 
   const focusClasses = {
-    gray: "focus-visible:[outline:var(--focus-outline-default)]",
-    blue: "focus-visible:[outline:var(--focus-outline-blue)]",
-    green: "focus-visible:[outline:var(--focus-outline-green)]",
-    red: "focus-visible:[outline:var(--focus-outline-red)]",
+    gray: "focus-visible:outline-2 focus-visible:outline-default",
+    blue: "focus-visible:outline-2 focus-visible:outline-blue",
+    green: "focus-visible:outline-2 focus-visible:outline-green",
+    red: "focus-visible:outline-2 focus-visible:outline-red",
   }[theme];
 
   const variantClasses = {

--- a/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
+++ b/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
@@ -33,8 +33,8 @@ const Checkbox: React.FC<CheckboxProps> = ({
     const interactionClasses = disabled
       ? ""
       : padding
-        ? "focus:ring-0"
-        : "hover:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 active:bg-surface-gray-2";
+        ? "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+        : "hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 active:bg-surface-gray-2";
 
     const sizeClasses: string = {
       sm: "w-3.5 h-3.5",

--- a/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
+++ b/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
@@ -33,8 +33,8 @@ const Checkbox: React.FC<CheckboxProps> = ({
     const interactionClasses = disabled
       ? ""
       : padding
-        ? "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
-        : "hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3 active:bg-surface-gray-2";
+        ? ""
+        : "hover:shadow-sm active:bg-surface-gray-2";
 
     const sizeClasses: string = {
       sm: "w-3.5 h-3.5",

--- a/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
+++ b/packages/frappe-ui-react/src/components/checkbox/checkbox.tsx
@@ -56,7 +56,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
 
     const interactionClasses =
       padding && !disabled
-        ? "focus-within:bg-surface-gray-2 focus-within:ring-2 focus-within:ring-outline-gray-3 hover:bg-surface-gray-3 active:bg-surface-gray-4"
+        ? "focus-within:bg-surface-gray-2 focus-within:outline-2 focus-within:outline-default hover:bg-surface-gray-3 active:bg-surface-gray-4"
         : "";
 
     return `inline-flex space-x-2 rounded transition ${paddingClasses} ${interactionClasses}`;

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -33,6 +33,7 @@ import { cn } from "../../utils";
 import { Check, SmallClose, SmallDown } from "../../icons";
 
 export const Combobox: React.FC<ComboboxProps> = ({
+  id,
   options,
   value,
   placeholder,
@@ -197,6 +198,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
             </span>
           )}
           <BaseCombobox.Input
+            id={id}
             className={cn(
               "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 outline-none focus:border-outline-gray-4 focus:ring-2 focus:ring-outline-gray-3 disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
               hasSelectedIcon ? "pl-8" : "pl-2",

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -200,7 +200,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
           <BaseCombobox.Input
             id={id}
             className={cn(
-              "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 outline-none focus:border-outline-gray-4 focus:ring-2 focus:ring-outline-gray-3 disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
+              "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
               hasSelectedIcon ? "pl-8" : "pl-2",
               showClear
                 ? loading

--- a/packages/frappe-ui-react/src/components/combobox/combobox.tsx
+++ b/packages/frappe-ui-react/src/components/combobox/combobox.tsx
@@ -200,7 +200,7 @@ export const Combobox: React.FC<ComboboxProps> = ({
           <BaseCombobox.Input
             id={id}
             className={cn(
-              "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
+              "min-h-6 w-full rounded border border-surface-gray-2 bg-surface-gray-2 py-1 text-base text-ink-gray-8 transition-colors placeholder-ink-gray-4 focus-visible:outline-2 focus-visible:outline-default disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
               hasSelectedIcon ? "pl-8" : "pl-2",
               showClear
                 ? loading

--- a/packages/frappe-ui-react/src/components/combobox/types.ts
+++ b/packages/frappe-ui-react/src/components/combobox/types.ts
@@ -12,6 +12,7 @@ export type GroupedOption = { group: string; options: SimpleOption[] };
 export type ComboboxOption = SimpleOption | GroupedOption;
 
 export interface ComboboxProps {
+  id?: string;
   options: ComboboxOption[];
   value?: string | null;
   placeholder?: string;

--- a/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
@@ -136,7 +136,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         nativeButton={false}
         render={
           children ? (
-            <span className="!mb-0">
+            <span className="mb-0! rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3">
               {children({
                 isOpen: open,
                 displayValue,

--- a/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
@@ -257,7 +257,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                           <button
                             key={val}
                             type="button"
-                            className={`flex h-8 w-8 items-center justify-center rounded cursor-pointer text-sm focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                            className={`flex h-8 w-8 items-center justify-center rounded cursor-pointer text-sm focus-visible:outline-2 focus-visible:outline-default ${
                               inMonth ? "text-ink-gray-8" : "text-ink-gray-3"
                             } ${
                               isToday ? "font-extrabold text-ink-gray-9" : ""
@@ -294,7 +294,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                       <button
                         type="button"
                         key={m}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""
@@ -321,7 +321,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                       <button
                         type="button"
                         key={y}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""

--- a/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/datePicker.tsx
@@ -136,7 +136,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         nativeButton={false}
         render={
           children ? (
-            <span className="mb-0! rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3">
+            <span className="mb-0! rounded">
               {children({
                 isOpen: open,
                 displayValue,

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -125,7 +125,6 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
       <Popover.Trigger
         disabled={disabled}
         nativeButton={false}
-        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
         render={
           children ? (
             <span>

--- a/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateRangePicker.tsx
@@ -252,7 +252,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                             type="button"
                             key={val}
                             disabled={isDisallowed}
-                            className={`flex h-8 w-8 items-center justify-center text-sm rounded focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                            className={`flex h-8 w-8 items-center justify-center text-sm rounded focus-visible:outline-2 focus-visible:outline-default ${
                               isDisallowed
                                 ? "cursor-not-allowed"
                                 : "cursor-pointer hover:bg-surface-gray-2"
@@ -308,7 +308,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                       <button
                         type="button"
                         key={m}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""
@@ -335,7 +335,7 @@ export const DateRangePicker: React.FC<DateRangePickerProps> = ({
                       <button
                         type="button"
                         key={y}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""

--- a/packages/frappe-ui-react/src/components/datePicker/dateTimePicker.tsx
+++ b/packages/frappe-ui-react/src/components/datePicker/dateTimePicker.tsx
@@ -257,7 +257,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
                           <button
                             type="button"
                             key={val}
-                            className={`flex h-8 w-8 items-center justify-center rounded cursor-pointer text-sm focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                            className={`flex h-8 w-8 items-center justify-center rounded cursor-pointer text-sm focus-visible:outline-2 focus-visible:outline-default ${
                               inMonth ? "text-ink-gray-8" : "text-ink-gray-3"
                             } ${
                               isToday ? "font-extrabold text-ink-gray-9" : ""
@@ -291,7 +291,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
                       <button
                         type="button"
                         key={m}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""
@@ -318,7 +318,7 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
                       <button
                         type="button"
                         key={y}
-                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus:outline-none focus:ring-2 focus:ring-outline-gray-2 ${
+                        className={`py-2 text-sm rounded cursor-pointer text-center hover:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default ${
                           isSelected
                             ? "bg-surface-gray-6 text-ink-white hover:bg-surface-gray-6"
                             : ""

--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
@@ -153,6 +153,7 @@ const durationSpinnerVariants = cva(
 );
 
 const DurationInput = ({
+  id,
   label,
   required = false,
   inlineLabel,
@@ -170,7 +171,8 @@ const DurationInput = ({
   classNames = {},
   onChange,
 }: DurationInputProps) => {
-  const sliderId = useId();
+  const generatedId = useId();
+  const sliderId = id ?? generatedId;
   const [draftValue, setDraftValue] = useState<string | null>(null);
   const [dragValue, setDragValue] = useState<number | null>(null);
 

--- a/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
+++ b/packages/frappe-ui-react/src/components/durationInput/durationInput.tsx
@@ -28,7 +28,7 @@ import { Spinner } from "../spinner";
 type SliderValue = number | readonly number[];
 
 const durationControlVariants = cva(
-  "flex items-center rounded relative overflow-hidden has-focus-visible:border-outline-gray-4 has-focus-visible:shadow-sm has-focus-visible:ring-2 cursor-pointer data-dragging:cursor-grabbing data-disabled:cursor-not-allowed",
+  "flex items-center rounded relative overflow-hidden has-focus-visible:border-outline-gray-4 has-focus-visible:shadow-sm cursor-pointer data-dragging:cursor-grabbing data-disabled:cursor-not-allowed",
   {
     variants: {
       variant: {
@@ -36,8 +36,8 @@ const durationControlVariants = cva(
         outline: "ring-1 ring-outline-gray-2",
       },
       error: {
-        true: "has-focus-visible:ring-outline-red-2",
-        false: "has-focus-visible:ring-outline-gray-3",
+        true: "has-focus-visible:outline-2 has-focus-visible:outline-red",
+        false: "has-focus-visible:outline-2 has-focus-visible:outline-default",
       },
     },
     compoundVariants: [
@@ -113,7 +113,7 @@ const durationIndicatorVariants = cva(
 );
 
 const durationInputVariants = cva(
-  "absolute -translate-y-1/2 top-1/2 right-2.5 w-10 flex items-center justify-center tabular-nums rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
+  "absolute -translate-y-1/2 top-1/2 right-2.5 w-10 flex items-center justify-center tabular-nums rounded-sm focus-visible:outline-offset-1",
   {
     variants: {
       size: {
@@ -125,8 +125,8 @@ const durationInputVariants = cva(
         false: "text-ink-gray-8",
       },
       error: {
-        true: "focus-visible:ring-outline-red-2 focus-visible:ring-offset-surface-red-2",
-        false: "focus-visible:ring-outline-gray-3",
+        true: "focus-visible:outline-2 focus-visible:outline-red",
+        false: "focus-visible:outline-2 focus-visible:outline-default",
       },
     },
     defaultVariants: {

--- a/packages/frappe-ui-react/src/components/durationInput/types.ts
+++ b/packages/frappe-ui-react/src/components/durationInput/types.ts
@@ -28,6 +28,8 @@ export interface DurationInputClassNames {
 }
 
 export interface DurationInputProps {
+  /** Overrides the generated id used to link an external label to the input. */
+  id?: string;
   /** Label displayed above the input. */
   label?: string | false;
   /** If true, appends a required-field asterisk to the label. */

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -171,8 +171,7 @@ export const Filter: React.FC<FilterProps> = ({
                   onClick={handleAddFilter}
                   className={cn(
                     "flex items-center gap-1.5 text-base text-ink-gray-5 px-2 py-1.5",
-                    "hover:text-ink-gray-7 mt-2 py-1 transition-colors rounded",
-                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+                    "hover:text-ink-gray-7 mt-2 py-1 transition-colors rounded"
                   )}
                 >
                   <Plus className="w-4 h-4" />

--- a/packages/frappe-ui-react/src/components/filter/filter.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filter.tsx
@@ -101,50 +101,46 @@ export const Filter: React.FC<FilterProps> = ({
     <div className={cn("inline-flex items-center", className)}>
       <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
         <Popover.Trigger
-          nativeButton={false}
+          nativeButton={true}
           render={
-            <span>
-              <Button
-                size="sm"
-                iconLeft={() => (
-                  <ListFilter size={16} className="text-ink-gray-7" />
-                )}
-                iconRight={
-                  !hasFilters
-                    ? () => (
-                        <ChevronDown size={16} className="text-ink-gray-5" />
-                      )
-                    : undefined
-                }
-                className={cn(
-                  "gap-2",
-                  {
-                    "rounded-r-none border-r-0": hasFilters,
-                  },
-                  triggerClassName
-                )}
-              >
-                Filter
-                {showCount && hasFilters && (
-                  <span className="ml-2 px-1.5 py-0.5 text-xs bg-surface-white rounded-sm shadow-sm">
-                    {filterCount}
-                  </span>
-                )}
-              </Button>
-
-              {/* Clear all button (shown when filters exist) */}
-              {hasFilters && (
-                <Button
-                  icon="x"
-                  size="sm"
-                  onClick={handleClearAll}
-                  className="rounded-l-none border-l border-l-outline-gray-2"
-                  aria-label="Clear all filters"
-                />
+            <Button
+              size="sm"
+              iconLeft={() => (
+                <ListFilter size={16} className="text-ink-gray-7" />
               )}
-            </span>
+              iconRight={
+                !hasFilters
+                  ? () => <ChevronDown size={16} className="text-ink-gray-5" />
+                  : undefined
+              }
+              className={cn(
+                "gap-2",
+                {
+                  "rounded-r-none border-r-0": hasFilters,
+                },
+                triggerClassName
+              )}
+            >
+              Filter
+              {showCount && hasFilters && (
+                <span className="ml-2 px-1.5 py-0.5 text-xs bg-surface-white rounded-sm shadow-sm">
+                  {filterCount}
+                </span>
+              )}
+            </Button>
           }
         />
+
+        {/* Clear all button (shown when filters exist) */}
+        {hasFilters && (
+          <Button
+            icon="x"
+            size="sm"
+            onClick={handleClearAll}
+            className="rounded-l-none border-l border-l-outline-gray-2"
+            aria-label="Clear all filters"
+          />
+        )}
 
         <Popover.Portal>
           <Popover.Positioner sideOffset={4} align={align}>
@@ -175,7 +171,8 @@ export const Filter: React.FC<FilterProps> = ({
                   onClick={handleAddFilter}
                   className={cn(
                     "flex items-center gap-1.5 text-base text-ink-gray-5 px-2 py-1.5",
-                    "hover:text-ink-gray-7 mt-2 py-1 transition-colors"
+                    "hover:text-ink-gray-7 mt-2 py-1 transition-colors rounded",
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3"
                   )}
                 >
                   <Plus className="w-4 h-4" />

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -269,7 +269,6 @@ export const FilterRow: React.FC<FilterRowProps> = ({
                 "rounded border-none min-w-35 bg-surface-gray-2",
                 "px-2 py-1 text-base min-h-7",
                 "placeholder-ink-gray-4 text-ink-gray-8",
-                "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
                 "transition-colors",
                 "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
               )}
@@ -309,7 +308,6 @@ const DatePickerTrigger: React.FC<DatePickerTriggerProps> = ({
       className={cn(
         "w-full rounded border-none bg-surface-gray-2",
         "py-1 pr-6 pl-2 text-base text-left min-h-7",
-        "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
         "transition-colors cursor-pointer",
         "truncate disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
         displayValue ? "text-ink-gray-8" : "text-ink-gray-4"

--- a/packages/frappe-ui-react/src/components/filter/filterRow.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterRow.tsx
@@ -269,7 +269,7 @@ export const FilterRow: React.FC<FilterRowProps> = ({
                 "rounded border-none min-w-35 bg-surface-gray-2",
                 "px-2 py-1 text-base min-h-7",
                 "placeholder-ink-gray-4 text-ink-gray-8",
-                "outline-none focus:ring-2 focus:ring-outline-gray-3",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
                 "transition-colors",
                 "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
               )}
@@ -309,7 +309,7 @@ const DatePickerTrigger: React.FC<DatePickerTriggerProps> = ({
       className={cn(
         "w-full rounded border-none bg-surface-gray-2",
         "py-1 pr-6 pl-2 text-base text-left min-h-7",
-        "outline-none focus:ring-2 focus:ring-outline-gray-3",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
         "transition-colors cursor-pointer",
         "truncate disabled:bg-surface-gray-1 disabled:text-ink-gray-5",
         displayValue ? "text-ink-gray-8" : "text-ink-gray-4"

--- a/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
@@ -125,7 +125,6 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
               selectedOption && getIcon(selectedOption) ? "pl-8" : "pl-2",
               "pr-6 py-1 min-h-7 text-base",
               "placeholder-ink-gray-4 text-ink-gray-7",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
               "transition-colors cursor-pointer",
               "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
             )}

--- a/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
+++ b/packages/frappe-ui-react/src/components/filter/filterSelect.tsx
@@ -125,7 +125,7 @@ export const FilterSelect: React.FC<FilterSelectProps> = ({
               selectedOption && getIcon(selectedOption) ? "pl-8" : "pl-2",
               "pr-6 py-1 min-h-7 text-base",
               "placeholder-ink-gray-4 text-ink-gray-7",
-              "outline-none focus:ring-2 focus:ring-outline-gray-3",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-outline-gray-3",
               "transition-colors cursor-pointer",
               "disabled:bg-surface-gray-1 disabled:text-ink-gray-5"
             )}

--- a/packages/frappe-ui-react/src/components/select/variants.ts
+++ b/packages/frappe-ui-react/src/components/select/variants.ts
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 
 export const selectTriggerVariants = cva(
-  "w-full inline-flex items-center justify-between gap-2 py-0 truncate appearance-none transition-colors focus:outline-none cursor-pointer disabled:cursor-not-allowed",
+  "w-full inline-flex items-center justify-between gap-2 py-0 truncate appearance-none transition-colors cursor-pointer disabled:cursor-not-allowed",
   {
     variants: {
       size: {
@@ -11,11 +11,11 @@ export const selectTriggerVariants = cva(
       },
       variant: {
         subtle:
-          "border border-surface-gray-2 bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 data-[placeholder]:text-ink-gray-4",
+          "border border-surface-gray-2 bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default data-[placeholder]:text-ink-gray-4",
         outline:
-          "border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3 focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+          "border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default",
         ghost:
-          "bg-transparent border-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3 focus:border-outline-gray-4 focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+          "bg-transparent border-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default",
       },
       disabled: {
         true: "text-ink-gray-4",

--- a/packages/frappe-ui-react/src/components/select/variants.ts
+++ b/packages/frappe-ui-react/src/components/select/variants.ts
@@ -11,11 +11,11 @@ export const selectTriggerVariants = cva(
       },
       variant: {
         subtle:
-          "border border-surface-gray-2 bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default data-[placeholder]:text-ink-gray-4",
+          "border border-surface-gray-2 bg-surface-gray-2 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus-visible:outline-2 focus-visible:outline-default data-[placeholder]:text-ink-gray-4",
         outline:
-          "border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default",
+          "border border-outline-gray-2 bg-surface-white hover:border-outline-gray-3 focus-visible:outline-2 focus-visible:outline-default",
         ghost:
-          "bg-transparent border-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3 focus:border-outline-gray-4 focus-visible:outline-2 focus-visible:outline-default",
+          "bg-transparent border-transparent hover:bg-surface-gray-3 focus:bg-surface-gray-3 focus-visible:outline-2 focus-visible:outline-default",
       },
       disabled: {
         true: "text-ink-gray-4",

--- a/packages/frappe-ui-react/src/components/sidebar/sidebarSection.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebarSection.tsx
@@ -46,7 +46,7 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
     >
       <Collapsible.Trigger
         className={cn(
-          "relative flex items-center gap-1 px-4 py-1.5 cursor-pointer rounded-md focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3 text-ink-gray-6",
+          "relative flex items-center gap-1 px-4 py-1.5 cursor-pointer rounded-md focus-visible:outline-2 focus-visible:outline-default text-ink-gray-6",
           {
             hidden: sidebarCollapsed,
           }

--- a/packages/frappe-ui-react/src/components/sidebar/sidebarSectionItem.tsx
+++ b/packages/frappe-ui-react/src/components/sidebar/sidebarSectionItem.tsx
@@ -49,7 +49,7 @@ const SidebarSectionItem: React.FC<SidebarSectionItemProps> = ({
     props: {
       onClick: item.onClick,
       className: cn(
-        "inline-flex h-7 w-full cursor-pointer items-center gap-2 rounded justify-start py-1 text-base text-left text-ink-gray-6 no-underline transition-all ease-in-out focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-3",
+        "inline-flex h-7 w-full cursor-pointer items-center gap-2 rounded justify-start py-1 text-base text-left text-ink-gray-6 no-underline transition-all ease-in-out focus-visible:outline-2 focus-visible:outline-default",
         indentClassName,
         {
           "!bg-surface-selected shadow-sm": item.isActive,

--- a/packages/frappe-ui-react/src/components/switch/switch.tsx
+++ b/packages/frappe-ui-react/src/components/switch/switch.tsx
@@ -35,7 +35,7 @@ const Switch: React.FC<SwitchProps> = ({
   // Classes
   const switchClasses = [
     "relative inline-flex flex-shrink-0 cursor-pointer rounded-full border-transparent transition-colors duration-100 ease-in-out items-center",
-    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3",
+    "focus-visible:outline-2 focus-visible:outline-default",
     "disabled:cursor-not-allowed disabled:bg-surface-gray-3",
     value
       ? "bg-surface-gray-7 enabled:hover:bg-surface-gray-6 active:bg-surface-gray-5"
@@ -76,7 +76,7 @@ const Switch: React.FC<SwitchProps> = ({
     const classes = ["flex justify-between"];
     if (switchType === SwitchVariant.ONLY_LABEL) {
       classes.push(
-        "group items-center space-x-3 cursor-pointer rounded focus-visible:bg-surface-gray-2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-outline-gray-3"
+        "group items-center space-x-3 cursor-pointer rounded focus-visible:bg-surface-gray-2 focus-visible:outline-2 focus-visible:outline-default"
       );
       classes.push(
         disabled

--- a/packages/frappe-ui-react/src/components/textEditor/extension/codeBlockNode.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/extension/codeBlockNode.tsx
@@ -31,7 +31,7 @@ function CodeBlockComponent(props: NodeViewProps) {
       <div className="code-block-container">
         <select
           name="language-options"
-          className="language-selector h-7 rounded-[8px] border border-surface-gray-2 bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base font-[420] leading-[1.15] tracking-[0.02em] text-ink-gray-8 transition-colors hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default"
+          className="language-selector h-7 rounded-[8px] border border-surface-gray-2 bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base font-[420] leading-[1.15] tracking-[0.02em] text-ink-gray-8 transition-colors hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default"
           value={selectedLanguage || "null"}
           onChange={handleLanguageChange}
         >

--- a/packages/frappe-ui-react/src/components/textEditor/extension/codeBlockNode.tsx
+++ b/packages/frappe-ui-react/src/components/textEditor/extension/codeBlockNode.tsx
@@ -31,7 +31,7 @@ function CodeBlockComponent(props: NodeViewProps) {
       <div className="code-block-container">
         <select
           name="language-options"
-          className="language-selector h-7 rounded-[8px] border border-surface-gray-2 bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base font-[420] leading-[1.15] tracking-[0.02em] text-ink-gray-8 transition-colors hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-white focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3"
+          className="language-selector h-7 rounded-[8px] border border-surface-gray-2 bg-surface-gray-2 py-1.5 pl-2 pr-2 text-base font-[420] leading-[1.15] tracking-[0.02em] text-ink-gray-8 transition-colors hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:border-outline-gray-4 focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default"
           value={selectedLanguage || "null"}
           onChange={handleLanguageChange}
         >

--- a/packages/frappe-ui-react/src/components/textInput/textInput.tsx
+++ b/packages/frappe-ui-react/src/components/textInput/textInput.tsx
@@ -22,9 +22,9 @@ const inputVariants = cva(
       },
       variant: {
         subtle:
-          "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+          "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
         outline:
-          "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+          "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
         ghost: "border-0 focus:ring-0 focus-visible:ring-0",
       },
       disabled: {

--- a/packages/frappe-ui-react/src/components/textInput/textInput.tsx
+++ b/packages/frappe-ui-react/src/components/textInput/textInput.tsx
@@ -11,7 +11,7 @@ import { cn } from "../../utils";
 import type { TextInputProps } from "./types";
 
 const inputVariants = cva(
-  "transition-colors w-full dark:[color-scheme:dark] outline-none appearance-none",
+  "transition-colors w-full dark:[color-scheme:dark] appearance-none",
   {
     variants: {
       size: {
@@ -22,9 +22,9 @@ const inputVariants = cva(
       },
       variant: {
         subtle:
-          "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+          "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
         outline:
-          "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
+          "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
         ghost: "border-0 focus:ring-0 focus-visible:ring-0",
       },
       disabled: {

--- a/packages/frappe-ui-react/src/components/textarea/variants.ts
+++ b/packages/frappe-ui-react/src/components/textarea/variants.ts
@@ -10,9 +10,9 @@ export const textareaVariants = cva("resize-y transition-colors w-full block", {
     },
     variant: {
       subtle:
-        "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+        "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
       outline:
-        "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+        "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
     },
     disabled: {
       true: "text-ink-gray-5",

--- a/packages/frappe-ui-react/src/components/textarea/variants.ts
+++ b/packages/frappe-ui-react/src/components/textarea/variants.ts
@@ -1,47 +1,44 @@
 import { cva } from "class-variance-authority";
 
-export const textareaVariants = cva(
-  "resize-y transition-colors w-full block outline-none",
-  {
-    variants: {
-      size: {
-        sm: "text-base rounded py-1.5 px-2",
-        md: "text-base rounded py-1.5 px-2.5",
-        lg: "text-lg rounded-md py-1.5 px-3",
-        xl: "text-xl rounded-md py-1.5 px-3",
-      },
-      variant: {
-        subtle:
-          "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
-        outline:
-          "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3",
-      },
-      disabled: {
-        true: "text-ink-gray-5",
-        false: "text-ink-gray-8",
-      },
+export const textareaVariants = cva("resize-y transition-colors w-full block", {
+  variants: {
+    size: {
+      sm: "text-base rounded py-1.5 px-2",
+      md: "text-base rounded py-1.5 px-2.5",
+      lg: "text-lg rounded-md py-1.5 px-3",
+      xl: "text-xl rounded-md py-1.5 px-3",
     },
-    compoundVariants: [
-      {
-        disabled: true,
-        variant: "subtle",
-        className:
-          "border border-transparent bg-surface-gray-1 placeholder-ink-gray-3",
-      },
-      {
-        disabled: true,
-        variant: "outline",
-        className:
-          "border border-outline-gray-2 bg-surface-gray-1 placeholder-ink-gray-3",
-      },
-    ],
-    defaultVariants: {
-      size: "sm",
+    variant: {
+      subtle:
+        "border border-surface-gray-2 bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+      outline:
+        "border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus-visible:outline-2 focus-visible:outline-default",
+    },
+    disabled: {
+      true: "text-ink-gray-5",
+      false: "text-ink-gray-8",
+    },
+  },
+  compoundVariants: [
+    {
+      disabled: true,
       variant: "subtle",
-      disabled: false,
+      className:
+        "border border-transparent bg-surface-gray-1 placeholder-ink-gray-3",
     },
-  }
-);
+    {
+      disabled: true,
+      variant: "outline",
+      className:
+        "border border-outline-gray-2 bg-surface-gray-1 placeholder-ink-gray-3",
+    },
+  ],
+  defaultVariants: {
+    size: "sm",
+    variant: "subtle",
+    disabled: false,
+  },
+});
 
 export const textareaLabelVariants = cva("block text-ink-gray-5", {
   variants: {

--- a/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
+++ b/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
@@ -48,7 +48,7 @@ const FocusRing = () => {
         <p className="text-sm text-ink-gray-6 mb-4">
           Retheme a specific element with{" "}
           <code className="text-ink-gray-8">
-            {"focus-visible:[outline:var(--focus-outline-<color>)]"}
+            {"focus-visible:outline-2 focus-visible:outline-<color>"}
           </code>
           , e.g. red for a form error or green for a success state.
         </p>

--- a/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
+++ b/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
@@ -4,11 +4,6 @@ import { Button } from "../button";
 import { Checkbox } from "../checkbox";
 import { TextInput } from "../textInput";
 
-// Literal `var(--focus-outline-*)` strings on purpose, applied via inline
-// style rather than a `focus-ring-<color>` utility class — Tailwind's JIT
-// only emits classes it can see literally in source, and there is no such
-// utility registered here (see theme.css: the ring is applied globally via
-// `:focus-visible`, themed variants override `outline` directly).
 const FOCUS_RINGS = [
   { label: "--focus-outline-default", variable: "--focus-outline-default" },
   { label: "--focus-outline-red", variable: "--focus-outline-red" },

--- a/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
+++ b/packages/frappe-ui-react/src/components/themeShowCase/focus-ring.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../button";
+import { Checkbox } from "../checkbox";
+import { TextInput } from "../textInput";
+
+// Literal `var(--focus-outline-*)` strings on purpose, applied via inline
+// style rather than a `focus-ring-<color>` utility class — Tailwind's JIT
+// only emits classes it can see literally in source, and there is no such
+// utility registered here (see theme.css: the ring is applied globally via
+// `:focus-visible`, themed variants override `outline` directly).
+const FOCUS_RINGS = [
+  { label: "--focus-outline-default", variable: "--focus-outline-default" },
+  { label: "--focus-outline-red", variable: "--focus-outline-red" },
+  { label: "--focus-outline-green", variable: "--focus-outline-green" },
+  { label: "--focus-outline-amber", variable: "--focus-outline-amber" },
+  { label: "--focus-outline-blue", variable: "--focus-outline-blue" },
+];
+
+const FocusRing = () => {
+  return (
+    <div className="p-8 max-w-3xl">
+      <h1 className="text-3xl font-bold mb-2">Focus Ring</h1>
+      <p className="text-ink-gray-6 mb-8 max-w-xl">
+        A single keyboard focus indicator, applied globally via{" "}
+        <code className="text-ink-gray-8">:focus-visible</code> in{" "}
+        <code className="text-ink-gray-8">theme.css</code>. Every focusable
+        element gets a correctly styled ring with zero classes, and it only
+        shows for keyboard navigation &mdash; mouse clicks never trigger it.
+      </p>
+
+      <section className="mb-12">
+        <h2 className="text-xl font-semibold mb-4">Live example</h2>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button label="Button" />
+          <Button theme="red" label="Red button" />
+          <Button theme="green" label="Green button" />
+          <Button theme="blue" label="Blue button" />
+          <TextInput placeholder="Text input" />
+          <Checkbox label="Checkbox" value={true} onChange={() => {}} />
+          <a href="#" className="text-ink-blue-3 underline">
+            Link
+          </a>
+        </div>
+        <p className="text-xs text-ink-gray-5 mt-3">
+          Tab into these to see the ring &mdash; clicking with a mouse won't
+          show it.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Tokens</h2>
+        <p className="text-sm text-ink-gray-6 mb-4">
+          Retheme a specific element with{" "}
+          <code className="text-ink-gray-8">
+            {"focus-visible:[outline:var(--focus-outline-<color>)]"}
+          </code>
+          , e.g. red for a form error or green for a success state.
+        </p>
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-6">
+          {FOCUS_RINGS.map((ring) => (
+            <div key={ring.label} className="grid gap-2">
+              <div
+                className="h-16 rounded-lg bg-surface-white border border-outline-gray-1"
+                style={{
+                  outline: `var(${ring.variable})`,
+                  outlineOffset: "2px",
+                }}
+              />
+              <span className="text-xs font-mono text-ink-gray-7">
+                {ring.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const meta: Meta<typeof FocusRing> = {
+  title: "DesignSystem/Focus Ring",
+  component: FocusRing,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <FocusRing />,
+};

--- a/packages/frappe-ui-react/src/components/toast/toast.tsx
+++ b/packages/frappe-ui-react/src/components/toast/toast.tsx
@@ -44,10 +44,10 @@ const ToastComponent: React.FC<ToastProps> = ({ toast }) => {
           </div>
         </div>
         <div className="flex items-center gap-2 h-7">
-          <Toast.Action className="flex-shrink-0 rounded px-2 py-1 text-sm text-ink-blue-link dark:text-gray-300 hover:text-ink-gray-3 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-4" />
+          <Toast.Action className="flex-shrink-0 rounded px-2 py-1 text-sm text-ink-blue-link dark:text-gray-300 hover:text-ink-gray-3 focus-visible:outline-2 focus-visible:outline-default" />
           {closable && (
             <Toast.Close
-              className="flex-shrink-0 rounded p-1 text-ink-white dark:text-gray-300 hover:text-ink-gray-3 focus:outline-none focus-visible:ring focus-visible:ring-outline-gray-4"
+              className="flex-shrink-0 rounded p-1 text-ink-white dark:text-gray-300 hover:text-ink-gray-3 focus-visible:outline-2 focus-visible:outline-default"
               aria-label="Close"
             >
               <X className="size-4" />

--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -781,6 +781,6 @@ input {
   :focus-visible {
     outline: var(--focus-outline-default);
     outline-offset: 0px;
-    transition: none !important;
+    transition: outline-color 0s !important;
   }
 }

--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -781,5 +781,6 @@ input {
   :focus-visible {
     outline: var(--focus-outline-default);
     outline-offset: 0px;
+    transition: none !important;
   }
 }

--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -465,6 +465,13 @@ input {
     --color-outline-orange-1: var(--color-orange-400);
     --color-outline-gray-modals: var(--color-gray-200);
 
+    /* Focus Ring */
+    --focus-outline-default: 2px solid var(--color-outline-gray-3);
+    --focus-outline-red: 2px solid var(--color-outline-red-2);
+    --focus-outline-green: 2px solid var(--color-outline-green-2);
+    --focus-outline-amber: 2px solid var(--color-outline-amber-2);
+    --focus-outline-blue: 2px solid var(--color-outline-blue-1);
+
     /* Border Radius */
     --radius-none: 0px;
     --radius-sm: 0.25rem;
@@ -770,4 +777,9 @@ input {
     --shadow-2xl: 0px 0px 1px rgba(0, 0, 0, 0.6),
       0px 1px 3px rgba(0, 0, 0, 0.15), 0px 10px 24px -3px rgba(0, 0, 0, 0.3);
   }
+
+    :focus-visible {
+        outline: var(--focus-outline-default);
+        outline-offset: 0px;
+    }
 }

--- a/packages/frappe-ui-react/src/theme.css
+++ b/packages/frappe-ui-react/src/theme.css
@@ -778,8 +778,8 @@ input {
       0px 1px 3px rgba(0, 0, 0, 0.15), 0px 10px 24px -3px rgba(0, 0, 0, 0.3);
   }
 
-    :focus-visible {
-        outline: var(--focus-outline-default);
-        outline-offset: 0px;
-    }
+  :focus-visible {
+    outline: var(--focus-outline-default);
+    outline-offset: 0px;
+  }
 }

--- a/packages/frappe-ui-react/src/themeV3.css
+++ b/packages/frappe-ui-react/src/themeV3.css
@@ -461,6 +461,13 @@ input {
   --color-outline-orange-1: var(--color-orange-400);
   --color-outline-gray-modals: var(--color-gray-200);
 
+  /* Focus Ring */
+  --focus-outline-default: 2px solid var(--color-outline-gray-3);
+  --focus-outline-red: 2px solid var(--color-outline-red-2);
+  --focus-outline-green: 2px solid var(--color-outline-green-2);
+  --focus-outline-amber: 2px solid var(--color-outline-amber-2);
+  --focus-outline-blue: 2px solid var(--color-outline-blue-1);
+
   /* Border Radius */
   --radius-none: 0px;
   --radius-sm: 0.25rem;
@@ -768,4 +775,10 @@ input {
     --shadow-2xl: 0px 0px 1px rgba(0, 0, 0, 0.6),
       0px 1px 3px rgba(0, 0, 0, 0.15), 0px 10px 24px -3px rgba(0, 0, 0, 0.3);
   }
+}
+
+:focus-visible {
+  outline: var(--focus-outline-default);
+  outline-offset: 0px;
+  transition: outline-color 0s !important;
 }

--- a/packages/frappe-ui-react/src/utils/tailwindExtend.json
+++ b/packages/frappe-ui-react/src/utils/tailwindExtend.json
@@ -859,6 +859,13 @@
       "gray-modals": "var(--color-outline-gray-modals)"
     }
   },
+  "outlineColor": {
+    "default": "var(--color-outline-gray-3)",
+    "red": "var(--color-outline-red-2)",
+    "green": "var(--color-outline-green-2)",
+    "amber": "var(--color-outline-amber-2)",
+    "blue": "var(--color-outline-blue-1)"
+  },
   "divideColor": {
     "outline": {
       "white": "var(--color-outline-white)",


### PR DESCRIPTION
## Description
Focus rings were inconsistent across components - some missing entirely, some showing both the browser's default outline and a custom ring, colors not matching. Combobox and DurationInput also had no `id` prop, so labels couldn't be linked to them.

- Added `id` support to Combobox and DurationInput for label linking.
- Replaced per-component focus classes with one global `:focus-visible` rule + `--focus-outline-*` tokens in theme.css. Every focusable element gets a correct ring automatically now; Button just overrides the color per theme. Same approach Frappe UI uses: https://ui.frappe.io/docs/foundations/focus-ring
- Added a Storybook page documenting it.
- Port `--focus-outline-*` tokens + the global `:focus-visible` rule to `themeV3.css` (was only in `theme.css`, so Tailwind v3 consumers had no focus indicator).
- Migrate the remaining `ring-*`-based components (DatePicker family, AutoComplete, Combobox, Checkbox, DurationInput, TextInput, Textarea, Select, Sidebar, Switch, Toast) to the new outline mechanism, fixing a few spots that used `focus:` instead of `focus-visible:` and showed the ring on mouse clicks.
- Swap the arbitrary-value `[outline:var(--focus-outline-*)]` classes for real utility classes (`outline-2 outline-<color>`) via a new `outlineColor` theme extension.

## Relevant Technical Choices
#### Why `transition: outline-color 0s !important;` under `:focus-visible` in `theme.css`?
Tailwind's .transition-colors/.transition-all utilities (used all over for hover fades) include outline-color in their transition list, so an unfocused element's outline-color sits at its unset value (near-black) and visibly animates to the token color when :focus-visible fires, instead of snapping. Forcing outline-color's transition to 0s kills that animation. It needs !important because those utility classes live in Tailwind's utilities layer, which always outranks this base-layer rule otherwise. Scoping to just outline-color (not transition: none) means every other transitioning property — background, text color, borders, transform, opacity - keeps working normally while the element is focused.

## Testing Instructions
Tab through Button, Checkbox, DatePicker, Combobox, Filter — one ring, correct color, no double outline. Check `DesignSystem/Focus Ring` in Storybook.

## Screenshot/Screencast

https://github.com/user-attachments/assets/a1a304b8-9704-40e7-bc1b-c421baa7a8ca

---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [x] I have reviewed the code myself before requesting a review.
- [ ] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

Partially addresses https://github.com/rtCamp/next-pms/issues/1662
