### PR TITLE
fix: AutoComplete and MultiSelect option selection issues

### DIFF
--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
@@ -336,5 +336,24 @@ export const ControlledSearchLoading: Story = {
     });
 
     expect(trigger).toHaveTextContent("John Doe, Jane Doe, John Smith");
+
+    await userEvent.type(search, "smith");
+
+    await waitFor(() => {
+      expect(page.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+    });
+
+    // Dismissing with an active query still resets it, so a reopen starts fresh.
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+
+    const reopenedSearch = await page.findByPlaceholderText("Search");
+    expect(reopenedSearch).toHaveValue("");
+
+    await waitFor(() => {
+      expect(page.getByText("Bob Johnson")).toBeInTheDocument();
+    });
+
+    expect(trigger).toHaveTextContent("John Doe, Jane Doe, John Smith");
   },
 };

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.interactions.stories.tsx
@@ -306,5 +306,35 @@ export const ControlledSearchLoading: Story = {
 
     expect(page.getByText("John Doe")).toBeInTheDocument();
     expect(page.getByText("Jane Doe")).toBeInTheDocument();
+
+    await userEvent.clear(search);
+    await userEvent.type(search, "smith");
+
+    await waitFor(() => {
+      expect(page.queryByTestId("loading-indicator")).not.toBeInTheDocument();
+    });
+
+    expect(page.getByText("John Smith")).toBeInTheDocument();
+
+    // Picking an option must not wipe the query or the results behind it.
+    await userEvent.click(page.getByText("John Smith"));
+
+    expect(search).toHaveValue("smith");
+    expect(page.getByText("John Smith")).toBeInTheDocument();
+    expect(page.queryByText("Bob Johnson")).not.toBeInTheDocument();
+    expect(trigger).toHaveTextContent("John Smith");
+
+    // The search clear button drops the query only, never the selection.
+    await userEvent.click(page.getByRole("button", { name: "Clear" }));
+
+    await waitFor(() => {
+      expect(search).toHaveValue("");
+    });
+
+    await waitFor(() => {
+      expect(page.getByText("Bob Johnson")).toBeInTheDocument();
+    });
+
+    expect(trigger).toHaveTextContent("John Doe, Jane Doe, John Smith");
   },
 };

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -194,7 +194,9 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
 
   const handleComboboxChange = useCallback(
     (val: InternalSelection) => {
-      updateQuery("");
+      if (!multiple) {
+        updateQuery("");
+      }
 
       const nextSelectedOptionCache = getNextSelectedOptionCache(val, multiple);
 
@@ -260,7 +262,6 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   const clearAll = useCallback(() => {
     if (multiple) {
       handleComboboxChange([]);
-      return;
     }
 
     updateQuery("");
@@ -269,9 +270,10 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
   const handleClearClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      clearAll();
+      updateQuery("");
+      searchInputRef.current?.focus();
     },
-    [clearAll]
+    [updateQuery]
   );
 
   useEffect(() => {
@@ -358,6 +360,12 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
         onOpenChange={(nextOpen) => setPopupOpen(nextOpen)}
         onInputValueChange={(nextQuery, details) => {
           if (details.reason === "item-press") {
+            return;
+          }
+
+          // Base-ui Combobox clears the input on item selection, but we want to keep
+          // the query for multi-select so more values can be picked from the same result set.
+          if (multiple && popupOpen && details.reason === "input-clear") {
             return;
           }
 

--- a/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
+++ b/packages/frappe-ui-react/src/components/autoComplete/autoComplete.tsx
@@ -113,6 +113,19 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
     [displayedGroups]
   );
 
+  const getLabel = useCallback((option: AutocompleteOption): string => {
+    return getOptionLabel(option);
+  }, []);
+
+  const selectedComboboxValue = useMemo<InternalSelection>(() => {
+    return resolveSelectedOptions({
+      value,
+      multiple,
+      currentOptions,
+      selectedOptionCache,
+    });
+  }, [value, multiple, currentOptions, selectedOptionCache]);
+
   const visibleGroups = useMemo(() => {
     const effectiveQuery = isSearchControlled && !loading ? "" : query;
     const filtered = filterGroups(displayedGroups, effectiveQuery, maxOptions);
@@ -120,10 +133,10 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
     if (!keepSelectedVisible) return filtered;
 
     // Ensure selected options are visible even if they don't match the query.
-    const selectionArray = Array.isArray(selectedOptionCache)
-      ? selectedOptionCache
-      : selectedOptionCache
-        ? [selectedOptionCache]
+    const selectionArray = Array.isArray(selectedComboboxValue)
+      ? selectedComboboxValue
+      : selectedComboboxValue
+        ? [selectedComboboxValue]
         : [];
 
     if (!selectionArray.length) return filtered;
@@ -149,26 +162,13 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
     loading,
     maxOptions,
     query,
-    selectedOptionCache,
+    selectedComboboxValue,
   ]);
 
   const renderedOptions = useMemo(
     () => flattenGroups(visibleGroups),
     [visibleGroups]
   );
-
-  const getLabel = useCallback((option: AutocompleteOption): string => {
-    return getOptionLabel(option);
-  }, []);
-
-  const selectedComboboxValue = useMemo<InternalSelection>(() => {
-    return resolveSelectedOptions({
-      value,
-      multiple,
-      currentOptions,
-      selectedOptionCache,
-    });
-  }, [value, multiple, currentOptions, selectedOptionCache]);
 
   const updateQuery = useCallback(
     (nextQuery: string) => {
@@ -183,21 +183,21 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
 
   const setPopupOpen = useCallback(
     (nextOpen: boolean) => {
+      if (!nextOpen && query) {
+        updateQuery("");
+      }
+
       if (!isOpenControlled) {
         setInternalOpen(nextOpen);
       }
 
       onOpenChange?.(nextOpen);
     },
-    [isOpenControlled, onOpenChange]
+    [isOpenControlled, onOpenChange, query, updateQuery]
   );
 
   const handleComboboxChange = useCallback(
     (val: InternalSelection) => {
-      if (!multiple) {
-        updateQuery("");
-      }
-
       const nextSelectedOptionCache = getNextSelectedOptionCache(val, multiple);
 
       if (nextSelectedOptionCache !== undefined) {
@@ -215,7 +215,7 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
 
       onChange?.(emittedValue, val);
     },
-    [multiple, onChange, setPopupOpen, updateQuery]
+    [multiple, onChange, setPopupOpen]
   );
 
   const displayValue = useMemo<string>(() => {
@@ -352,20 +352,16 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
         value={selectedComboboxValue}
         multiple={multiple}
         open={popupOpen}
+        inputValue={query}
         autoHighlight
         filter={null}
         highlightItemOnHover
         itemToStringLabel={(item) => item.label}
         isItemEqualToValue={isSameOption}
-        onOpenChange={(nextOpen) => setPopupOpen(nextOpen)}
+        onOpenChange={setPopupOpen}
         onInputValueChange={(nextQuery, details) => {
-          if (details.reason === "item-press") {
-            return;
-          }
-
-          // Base-ui Combobox clears the input on item selection, but we want to keep
-          // the query for multi-select so more values can be picked from the same result set.
-          if (multiple && popupOpen && details.reason === "input-clear") {
+          // Only update the query if the change was triggered by user input.
+          if (details.reason !== "input-change") {
             return;
           }
 
@@ -411,7 +407,6 @@ const Autocomplete: React.FC<AutocompleteProps> = ({
                       id={comboboxInputId}
                       ref={searchInputRef}
                       data-testid="autocomplete"
-                      value={query}
                       placeholder="Search"
                       autoComplete="off"
                       className={cn(

--- a/packages/frappe-ui-react/src/components/autoComplete/utils.ts
+++ b/packages/frappe-ui-react/src/components/autoComplete/utils.ts
@@ -285,9 +285,7 @@ export const getNextSelectedOptionCache = (
   multiple: boolean
 ) => {
   if (multiple) {
-    return Array.isArray(selection) && selection.length > 0
-      ? selection
-      : undefined;
+    return Array.isArray(selection) ? selection : undefined;
   }
 
   return selection && !Array.isArray(selection) ? selection : undefined;

--- a/packages/frappe-ui-react/src/components/multiSelect/multiSelect.interactions.stories.tsx
+++ b/packages/frappe-ui-react/src/components/multiSelect/multiSelect.interactions.stories.tsx
@@ -199,36 +199,42 @@ export const SearchOptions: Story = {
 
     // Find search input
     const searchInput = await screen.findByPlaceholderText("Search for...");
-    expect(searchInput).toBeInTheDocument();
-
-    // Type in search
     await userEvent.type(searchInput, "ber");
 
-    // Elderberry should be visible
-    const elderberryOption = screen.getByText("Elderberry");
-    expect(elderberryOption).toBeInTheDocument();
+    const elderberryOption = await screen.findByRole("option", {
+      name: "Elderberry",
+    });
+    expect(
+      screen.queryByRole("option", { name: "Apple" })
+    ).not.toBeInTheDocument();
 
-    // Apple should not be visible
-    const appleOption = screen.queryByText("Apple");
-    expect(appleOption).not.toBeInTheDocument();
+    // Picking an option must not wipe the query or the results behind it
+    await userEvent.click(elderberryOption);
+
+    expect(searchInput).toHaveValue("ber");
+    expect(
+      screen.queryByRole("option", { name: "Apple" })
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(trigger).toHaveTextContent("Elderberry");
+    });
 
     // Type search that has no results
     await userEvent.type(searchInput, "xyz123");
 
-    // Verify "No results found" message appears
-    const noResultsMessage = await screen.findByText("No results found");
-    expect(noResultsMessage).toBeInTheDocument();
+    expect(await screen.findByText("No results found")).toBeInTheDocument();
 
-    // Find and click the clear button
-    const clearButton = await screen.findByRole("button", {
-      name: /clear search/i,
-    });
-    expect(clearButton).toBeInTheDocument();
+    // The clear button drops the query only, never the selection
+    await userEvent.click(
+      await screen.findByRole("button", { name: /clear search/i })
+    );
 
-    await userEvent.click(clearButton as HTMLElement);
-
-    // Verify search input is cleared
     expect(searchInput).toHaveValue("");
+    expect(
+      await screen.findByRole("option", { name: "Apple" })
+    ).toBeInTheDocument();
+    expect(trigger).toHaveTextContent("Elderberry");
   },
 };
 

--- a/packages/frappe-ui-react/src/components/multiSelect/multiSelect.tsx
+++ b/packages/frappe-ui-react/src/components/multiSelect/multiSelect.tsx
@@ -70,6 +70,9 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   }, [options, onChange]);
 
   const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setQuery("");
+    }
     if (open === undefined) {
       setPopupOpen(nextOpen);
     }
@@ -86,7 +89,15 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
       multiple
       open={resolvedOpen}
       value={selectedOptionObjects}
+      inputValue={query}
       onOpenChange={handleOpenChange}
+      onInputValueChange={(nextQuery, details) => {
+        // Only update the query if the change was triggered by user input.
+        if (details.reason !== "input-change") {
+          return;
+        }
+        setQuery(nextQuery);
+      }}
       onValueChange={handleChange}
       isItemEqualToValue={compareFn}
     >
@@ -118,7 +129,6 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
             {!hideSearch && (
               <div className="flex w-full items-center justify-between gap-2 rounded bg-surface-gray-2 px-2 py-1 ring-2 ring-outline-gray-2 transition-colors hover:bg-surface-gray-3 border border-transparent mb-2">
                 <Combobox.Input
-                  onChange={(e) => setQuery(e.target.value)}
                   placeholder="Search for..."
                   className="bg-transparent p-0 focus:outline-0 border-0 focus:border-0 focus:ring-0 text-base text-ink-gray-8 h-full placeholder:text-ink-gray-4 w-full"
                 />
@@ -126,13 +136,16 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
                   {loading && (
                     <LoadingIndicator className="size-4 text-ink-gray-5" />
                   )}
-                  <Combobox.Clear
-                    keepMounted={query !== ""}
-                    onClick={() => setQuery("")}
-                    aria-label="Clear search"
-                  >
-                    <X className="size-4 text-ink-gray-9" />
-                  </Combobox.Clear>
+                  {query !== "" && (
+                    <button
+                      type="button"
+                      aria-label="Clear search"
+                      onMouseDown={(event) => event.preventDefault()}
+                      onClick={() => setQuery("")}
+                    >
+                      <X className="size-4 text-ink-gray-9" />
+                    </button>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
<!--
⚠️ Adding a new component or feature?
Please open an issue for discussion first and wait for it to be approved before
starting work. PRs that add new components without a linked, approved issue may be closed.
-->

## Description

<!-- What do we want to achieve with this PR? -->
This PR updates the `Autocomplete` component's multi-select mode and `MultiSelect` component behavior so that selecting an option no longer clears the search query. The clear search button now only clears the search query instead of deselecting all selected options.


## Screenshot/Screencast

<!-- Please provide Screenshot/Screencast, if applicable -->


https://github.com/user-attachments/assets/812dd741-5152-4a2b-9e0c-451913b4d837



---

## Checklist

<!-- Check these after PR creation -->

- [ ] If this PR adds a new component, it has a linked issue that was discussed and approved before I started work.
- [x] I have thoroughly tested this code to the best of my abilities.
- [ ] I have reviewed the code myself before requesting a review.
- [x] This code is covered by unit tests to verify that it works as intended.
- [ ] The QA of this PR is done by a member of the QA team (to be checked by QA).

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Partially fixes https://github.com/rtCamp/next-pms/issues/2087
